### PR TITLE
Add bootstrap shim-name override

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,8 +45,8 @@ helix-theme-install-agent:
 helix-watch-config:
     nu ./scripts/watch-helix-config.nu
 
-bootstrap instance_name source_image="./scrubs/qcow2/scrubs.qcow2":
-    nu ./scrubs/bootstrap.nu --source-image {{ source_image }} {{ instance_name }}
+bootstrap instance_name source_image="./scrubs/qcow2/scrubs.qcow2" shim_name="":
+    nu ./scrubs/bootstrap.nu --source-image {{ source_image }} {{ if shim_name != "" { "--shim-name " + shim_name + " " } else { "" } }}{{ instance_name }}
 
 download-latest-iso channel="nixos-25.11":
     nu ./scrubs/download-latest-iso.nu {{ channel }}

--- a/scrubs/README.md
+++ b/scrubs/README.md
@@ -402,11 +402,16 @@ The next step after this base flow is a small per-project extension mechanism,
 so a repo can ask for extra packages or helper setup without owning the entire
 machine definition.
 
-That now exists in a minimal instance-keyed form:
+That now exists in a minimal instance-keyed form, with an optional shim-name
+override:
 
 - if [`scrubs/projects`](/Users/jem/dotfiles/scrubs/projects) contains a file named
   `<instance-name>.nix`, `just bootstrap ... <instance-name>` copies it into the
   guest payload as `modules/project-shim.nix`
+- if you want a public, non-project-specific shim filename, pass
+  `shim_name=<shim-name>` to `just bootstrap` or `--shim-name <shim-name>` to
+  [`bootstrap.nu`](/Users/jem/dotfiles/scrubs/bootstrap.nu); that copies
+  `scrubs/projects/<shim-name>.nix` instead
 - the shim is imported on top of the shared base config for that VM only
 
 This keeps project-specific accommodations in version control without baking

--- a/scrubs/bootstrap.nu
+++ b/scrubs/bootstrap.nu
@@ -45,6 +45,7 @@ def remote-shell-command [command: string] {
 def main [
   instance_name: string
   --source-image(-s): string = ""
+  --shim-name: string = ""
 ] {
   let repo_root = (repo-root)
   let scrubs_dir = (scrubs-dir)
@@ -54,7 +55,8 @@ def main [
   let payload_dir = ($cache_dir | path join "scrubs-bootstrap")
   let guest_apply = ($payload_dir | path join "guest-apply.sh")
   let template_file = ($scrubs_dir | path join "lima.local.yaml")
-  let project_shim_file = ($scrubs_dir | path join "projects" $"($instance_name).nix")
+  let resolved_shim_name = if $shim_name == "" { $instance_name } else { $shim_name }
+  let project_shim_file = ($scrubs_dir | path join "projects" $"($resolved_shim_name).nix")
   let instance_dir = ($env.HOME | path join ".lima" $instance_name)
   let current_user = (^id -un | str trim)
   let current_uid = (^id -u | str trim)

--- a/scrubs/projects/postgres-gcloud.nix
+++ b/scrubs/projects/postgres-gcloud.nix
@@ -1,0 +1,34 @@
+{ lib, pkgs, ... }:
+let
+  buildDeps = with pkgs; [
+    readline
+    zlib
+    openssl
+    e2fsprogs
+    icu
+    util-linux
+  ];
+in
+{
+  environment.systemPackages = with pkgs; [
+    bison
+    flex
+    gcc
+    gnumake
+    perl
+    pkg-config
+    python3
+  ]
+  ++ buildDeps
+  ++ [
+    (writeShellScriptBin "python" ''
+      exec ${python3}/bin/python3 "$@"
+    '')
+  ];
+
+  environment.variables = {
+    CPPFLAGS = lib.concatStringsSep " " (map (pkg: "-I${lib.getDev pkg}/include") buildDeps);
+    LDFLAGS = lib.concatStringsSep " " (map (pkg: "-L${lib.getLib pkg}/lib") buildDeps);
+    PKG_CONFIG_PATH = lib.makeSearchPathOutput "dev" "lib/pkgconfig" buildDeps;
+  };
+}


### PR DESCRIPTION
## Summary
- add an optional shim-name override to scrubs bootstrap
- allow public, non-project-specific shim filenames via just and bootstrap.nu
- rename the current shim to postgres-gcloud and document the workflow

## Testing
- nix-instantiate --parse scrubs/projects/postgres-gcloud.nix
- just --dry-run bootstrap <instance-name> ./scrubs/qcow2/scrubs.qcow2 postgres-gcloud
- verified real mise installs for gcloud@555.0.0 and postgres@18.1 inside the guest using the renamed shim