### PR TITLE
tailscale bootstrap mode

### DIFF
--- a/justfile
+++ b/justfile
@@ -45,8 +45,8 @@ helix-theme-install-agent:
 helix-watch-config:
     nu ./scripts/watch-helix-config.nu
 
-bootstrap instance_name clean_auth_profile="personal" shim_name="" source_image="./vms/images/scrubs.qcow2":
-    nu ./vms/bootstrap.nu --source-image {{ source_image }} {{ if shim_name != "" { "--shim-name " + shim_name + " " } else { "" } }}--clean-auth-profile {{ clean_auth_profile }} {{ instance_name }}
+bootstrap instance_name clean_auth_profile="personal" shim_name="" source_image="./vms/images/scrubs.qcow2" tailscale_mode="tailscale-enabled":
+    nu ./vms/bootstrap.nu --source-image {{ source_image }} {{ if shim_name != "" { "--shim-name " + shim_name + " " } else { "" } }}--clean-auth-profile {{ clean_auth_profile }} {{ instance_name }} {{ tailscale_mode }}
 
 download-latest-iso channel="nixos-25.11":
     nu ./vms/download-latest-iso.nu {{ channel }}

--- a/vms/README.md
+++ b/vms/README.md
@@ -638,18 +638,41 @@ The core questions are:
 4. does dirty space remain unable to discover or invoke the clean auth surface
 5. does ordinary HTTPS Git still work through the scrubs-owned `gh` helper path
 
+The intended operator process for future feature work is:
+
+1. treat the standard test guest as disposable and local-first
+2. prefer the existing Lima-local access paths such as `limactl shell <instance>`
+   and the host-local SSH bootstrap path during ordinary regression testing
+3. do not provision guest-side Tailscale as part of the default testing
+   procedure unless Tailscale behavior is itself part of what is being tested
+4. when a feature does need Tailscale coverage, treat that as an explicit
+   additional validation track rather than the baseline every feature must run
+
+This keeps short-lived test guests from accumulating stale tailnet nodes and
+helps preserve a clear distinction between the ordinary scrubs regression path
+and tests that intentionally exercise direct tailnet enrollment.
+
 For any new or materially changed guest flow, the baseline pass is:
 
 1. create a fresh throwaway guest
 2. confirm `limactl shell <instance>` opens an interactive shell
 3. confirm clean-space `gh` and Codex auth are usable without interactive login
-4. when Tailscale auth is configured, confirm `tailscale status` reports the guest as running and `tailscale set --ssh` state is active
-5. confirm dirty-space probes cannot discover `clean-auth`, `gh`, or `codex`
-6. confirm `git credential fill` succeeds for `github.com` through the scrubs helper path
-7. confirm an HTTPS read operation such as `git ls-remote` succeeds
-8. confirm a non-destructive push-shaped probe such as `git push --dry-run` succeeds when the configured token should allow it
-9. run `just bootstrap <instance>` again on that same guest
-10. confirm `limactl shell <instance>` still opens an interactive shell
+4. confirm dirty-space probes cannot discover `clean-auth`, `gh`, or `codex`
+5. confirm `git credential fill` succeeds for `github.com` through the scrubs helper path
+6. confirm an HTTPS read operation such as `git ls-remote` succeeds
+7. confirm a non-destructive push-shaped probe such as `git push --dry-run` succeeds when the configured token should allow it
+8. run `just bootstrap <instance>` again on that same guest
+9. confirm `limactl shell <instance>` still opens an interactive shell
+
+Add the following only when the specific feature or regression under test
+depends on guest-side Tailscale:
+
+1. bootstrap the guest through the explicit Tailscale-enabled path for that test
+2. confirm `tailscale status` reports the guest as running
+3. confirm `tailscale set --ssh` state is active if Tailscale SSH is part of
+   the intended behavior
+4. clean up the tailnet node afterward if the test intentionally created a
+   disposable enrolled guest
 
 This does not replace workload-specific validation, but it is the default
 guardrail for scrubs changes. A guest that cannot survive re-bootstrap without

--- a/vms/README.md
+++ b/vms/README.md
@@ -278,6 +278,9 @@ selected clean auth profile at bootstrap time. The model is:
 - default the selected profile to `personal`
 - optionally pick a different profile with `SCRUBS_CLEAN_AUTH_PROFILE=<name>`
   or `just bootstrap <instance> <profile>`
+- leave Tailscale enabled by default, or append `tailscale-disabled` as the
+  final bootstrap argument for disposable test guests that should stay off the
+  tailnet
 - define profile-specific overrides by appending `__<PROFILE>` to the base
   setting name, where `<PROFILE>` is the uppercased profile label with
   non-alphanumeric runs converted to `_`
@@ -375,6 +378,7 @@ So the common paths are:
 just bootstrap scrubs-dev
 just bootstrap sec-lab work
 just bootstrap sec-lab work security-testing /absolute/path/to/nixos.qcow2
+just bootstrap sec-lab work security-testing /absolute/path/to/nixos.qcow2 tailscale-disabled
 ```
 
 For rotation or cleanup:
@@ -407,6 +411,9 @@ tailnet does not silently replace the guest's existing DNS defaults. By
 default, scrubs requests `preauthorized=true` and `ephemeral=false`; if your
 tailnet policy wants different behavior, override
 `SCRUBS_TAILSCALE_PREAUTHORIZED` or `SCRUBS_TAILSCALE_EPHEMERAL`.
+If you are bootstrapping a disposable test guest and do not want tailnet
+enrollment at all, append `tailscale-disabled` as the final `just bootstrap`
+argument for that run.
 
 The intended setup flow is:
 
@@ -771,6 +778,13 @@ Or explicitly by shim name if you want a different instance name:
 
 ```sh
 just bootstrap sec-lab shim_name=security-testing source_image=/absolute/path/to/nixos.qcow2
+```
+
+To keep a disposable test guest off Tailscale while still using the standard
+bootstrap flow, append `tailscale-disabled` as the last argument:
+
+```sh
+just bootstrap sec-lab work security-testing /absolute/path/to/nixos.qcow2 tailscale-disabled
 ```
 
 Inside the guest:

--- a/vms/bootstrap.nu
+++ b/vms/bootstrap.nu
@@ -370,6 +370,18 @@ def resolve-tailscale-ephemeral [settings: record, profile_suffix: string] {
   $normalized in ["1", "true", "yes", "on"]
 }
 
+def resolve-tailscale-bootstrap-mode [tailscale_mode: string] {
+  let normalized = ($tailscale_mode | str trim | str downcase)
+
+  if $normalized not-in ["tailscale-enabled", "tailscale-disabled"] {
+    error make {
+      msg: $"Unsupported Tailscale bootstrap mode '($tailscale_mode)'. Use tailscale-enabled or tailscale-disabled."
+    }
+  }
+
+  $normalized
+}
+
 def write-sealed-secret [secret_value: string, key_path: string, ciphertext_path: string] {
   let plaintext_path = $"($ciphertext_path).plain"
 
@@ -420,6 +432,7 @@ def main [
   --source-image(-s): string = ""
   --shim-name: string = ""
   --clean-auth-profile(-p): string = ""
+  tailscale_mode: string = "tailscale-enabled"
 ] {
   let repo_root = (repo-root)
   let vms_dir = (vms-dir)
@@ -432,6 +445,7 @@ def main [
   let resolved_shim_name = if $shim_name == "" { $instance_name } else { $shim_name }
   let project_shim = (resolve-project-shim ($vms_dir | path join "projects") $resolved_shim_name)
   let selected_clean_auth_profile = (resolve-clean-auth-profile $settings $clean_auth_profile)
+  let resolved_tailscale_mode = (resolve-tailscale-bootstrap-mode $tailscale_mode)
   let instance_dir = ($env.HOME | path join ".lima" $instance_name)
   let current_user = (^id -un | str trim)
   let current_uid = (^id -u | str trim)
@@ -566,7 +580,12 @@ def main [
 
   let gh_token = (resolve-github-token $settings $selected_clean_auth_profile.name $selected_clean_auth_profile.suffix)
   let codex_auth_json = (resolve-codex-auth-json $settings $selected_clean_auth_profile.suffix)
-  let tailscale_oauth_secret = (resolve-tailscale-oauth-secret $settings $selected_clean_auth_profile.name $selected_clean_auth_profile.suffix)
+  let tailscale_enabled = ($resolved_tailscale_mode == "tailscale-enabled")
+  let tailscale_oauth_secret = if $tailscale_enabled {
+    (resolve-tailscale-oauth-secret $settings $selected_clean_auth_profile.name $selected_clean_auth_profile.suffix)
+  } else {
+    ""
+  }
   let tailscale_tags = if $tailscale_oauth_secret == "" { "" } else { resolve-tailscale-tags $settings $selected_clean_auth_profile.suffix }
   let tailscale_preauthorized = if $tailscale_oauth_secret == "" { false } else { resolve-tailscale-preauthorized $settings $selected_clean_auth_profile.suffix }
   let tailscale_ephemeral = if $tailscale_oauth_secret == "" { false } else { resolve-tailscale-ephemeral $settings $selected_clean_auth_profile.suffix }
@@ -591,6 +610,10 @@ def main [
 
   if $selected_clean_auth_profile.name != "" {
     print $"Selected clean auth profile: ($selected_clean_auth_profile.name)"
+  }
+
+  if not $tailscale_enabled {
+    print "Tailscale bootstrap mode: disabled"
   }
 
   if not ($enabled_clean_secrets | is-empty) {

--- a/vms/tasks/open/0017-improve-bootstrap-cli-as-scrubs-matures-into-a-package.pug
+++ b/vms/tasks/open/0017-improve-bootstrap-cli-as-scrubs-matures-into-a-package.pug
@@ -1,0 +1,43 @@
+issue(id="0017" status="open")
+  title Improve bootstrap CLI as scrubs matures into a package
+  user-story
+    as-a scrubs operator and maintainer using a growing set of bootstrap controls
+    i-want a more intentional command-line interface for scrubs operations
+    so-that new options can be added without making bootstrap usage awkward, fragile, or hard to discover
+  premise.
+    Scrubs currently exposes its main guest lifecycle entry points through a
+    `just` recipe plus a Nushell bootstrap script. That shape has worked well
+    while the surface area stayed small, but recent work such as selectable
+    clean-auth profiles, project shims, source-image overrides, and explicit
+    Tailscale bootstrap modes shows the command interface is beginning to grow
+    in both importance and complexity.
+
+    We do not need to redesign that interface immediately, and we do not need
+    to prematurely bundle unrelated behaviors into broad lifecycle modes just
+    because more than one option exists. The immediate product decision is to
+    keep adding narrowly scoped controls when they solve concrete operator
+    pain. The follow-on concern is package maturity: scrubs should eventually
+    present a clearer, more ergonomic CLI story than "keep extending one
+    bootstrap recipe forever."
+
+    The goal of this task is to explore what a more durable scrubs command
+    surface should look like as the tool grows up into an actual package. That
+    may include subcommands, named flags, stronger help output, clearer
+    defaults, or a higher-level wrapper around the current Nushell scripts, but
+    it should stay grounded in real operator workflows rather than abstract CLI
+    polish.
+  acceptance-criteria
+    criterion Scrubs has a documented assessment of the current bootstrap and guest-lifecycle command surface, including where positional arguments, optional controls, and discoverability are starting to strain.
+    criterion The design work evaluates at least two plausible future CLI directions, such as continuing to evolve the current `just` plus Nushell shape versus introducing a more package-like command wrapper with subcommands or named flags.
+    criterion The proposed direction explains how existing operator workflows such as bootstrap, validation, project shims, and clean-auth profile selection would map onto the future interface.
+    criterion The design explicitly distinguishes near-term ergonomic improvements from larger packaging or distribution changes, so maintainers can improve the CLI incrementally without blocking on a full rewrite.
+    criterion The final recommendation includes a migration strategy that avoids surprising existing scrubs operators and explains whether backward-compatible aliases or transitional wrappers are needed.
+  review-items
+    item(status="open").
+      Decide whether the long-term primary surface should remain `just`, shift
+      toward a dedicated scrubs command, or intentionally support both with
+      different audiences in mind.
+    item(status="open").
+      Decide how aggressively scrubs should move away from positional
+      bootstrap arguments toward named flags or subcommands as the option set
+      grows.

--- a/vms/tasks/review/0016-support-ephemeral-bootstrap-without-tailscale-enrollment.pug
+++ b/vms/tasks/review/0016-support-ephemeral-bootstrap-without-tailscale-enrollment.pug
@@ -1,4 +1,4 @@
-issue(id="0016" status="open")
+issue(id="0016" status="review")
   title Support ephemeral bootstrap without Tailscale enrollment
   user-story
     as-a scrubs operator booting disposable guests for testing or feature work
@@ -29,10 +29,12 @@ issue(id="0016" status="open")
     criterion The operator-facing invocation is documented with examples for common disposable workflows such as testing bootstrap or validating a feature in a short-lived instance.
     criterion Validation for the new path includes confirming that a disposable guest still bootstraps successfully and remains reachable through the existing local scrubs access path without appearing as a new tailnet node.
   review-items
-    item(status="open").
-      Decide whether the operator control should be a dedicated bootstrap flag,
-      a separate clean-auth or lifecycle profile concept, or a project-shim
-      level default for known disposable workflows.
+    item(status="covered").
+      The operator control now uses an explicit bootstrap-time mode on the
+      existing command surface. `just bootstrap` accepts a final
+      `tailscale_mode` argument, defaults it to `tailscale-enabled`, and
+      supports `tailscale-disabled` for disposable test guests without
+      introducing a separate lifecycle profile or project-shim-only mechanism.
     item(status="open").
       Decide whether the ephemeral path should also influence related defaults,
       such as naming, cleanup commands, or other guest services that only make

--- a/vms/tasks/review/0016-support-ephemeral-bootstrap-without-tailscale-enrollment.pug
+++ b/vms/tasks/review/0016-support-ephemeral-bootstrap-without-tailscale-enrollment.pug
@@ -35,7 +35,9 @@ issue(id="0016" status="review")
       `tailscale_mode` argument, defaults it to `tailscale-enabled`, and
       supports `tailscale-disabled` for disposable test guests without
       introducing a separate lifecycle profile or project-shim-only mechanism.
-    item(status="open").
-      Decide whether the ephemeral path should also influence related defaults,
-      such as naming, cleanup commands, or other guest services that only make
-      sense for longer-lived instances.
+    item(status="covered").
+      For now, the ephemeral path stays narrowly scoped to Tailscale
+      enrollment only. Additional disposable-guest behaviors such as naming,
+      cleanup commands, or suppression of other long-lived-only services can
+      be introduced later as separate explicit options if real operator need
+      emerges, rather than bundling multiple behaviors into this mode today.


### PR DESCRIPTION
## Summary
- document the default validation process as local-first and tailscale-free unless tailscale is under test
- add a final bootstrap mode argument that defaults to `tailscale-enabled` and supports `tailscale-disabled`
- move the ephemeral tailscale task to review and add a follow-up task for future bootstrap CLI ergonomics

## Testing
- `nu vms/bootstrap.nu --help`
- `just --dry-run bootstrap sec-lab work security-testing /absolute/path/to/nixos.qcow2 tailscale-disabled`