### PR TITLE
Fix Renovate scrubs Nix artifact updates

### DIFF
--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -43,7 +43,7 @@ jobs:
         env:
           LOG_LEVEL: debug
           RENOVATE_ALLOW_PLUGINS: true
-          RENOVATE_ALLOWED_COMMANDS: '["^nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update nixpkgs nixpkgs-unstable$"]'
+          RENOVATE_ALLOWED_COMMANDS: '["^nix flake lock(?: --update-input (nixpkgs|nixpkgs-unstable)){1,2}$","^nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update nixpkgs nixpkgs-unstable$"]'
           RENOVATE_REPOSITORIES: jeremybanka/dotfiles
         with:
           configurationFile: renovate.json

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,7 +9,6 @@ on:
   push:
     branches:
       - main
-      - fix-nix-artifact-update-failure
 
 permissions:
   contents: read
@@ -43,9 +42,7 @@ jobs:
         env:
           LOG_LEVEL: debug
           RENOVATE_ALLOW_PLUGINS: true
-          RENOVATE_ALLOWED_COMMANDS: '["^nix flake lock(?: --update-input (nixpkgs|nixpkgs-unstable)){1,2}$","^nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update nixpkgs nixpkgs-unstable$"]'
-          RENOVATE_REQUIRE_CONFIG: ignored
+          RENOVATE_ALLOWED_COMMANDS: '["^nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update nixpkgs nixpkgs-unstable$"]'
           RENOVATE_REPOSITORIES: jeremybanka/dotfiles
         with:
-          configurationFile: renovate.json
           token: ${{ steps.app-token.outputs.token }}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -44,6 +44,7 @@ jobs:
           LOG_LEVEL: debug
           RENOVATE_ALLOW_PLUGINS: true
           RENOVATE_ALLOWED_COMMANDS: '["^nix flake lock(?: --update-input (nixpkgs|nixpkgs-unstable)){1,2}$","^nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update nixpkgs nixpkgs-unstable$"]'
+          RENOVATE_REQUIRE_CONFIG: ignored
           RENOVATE_REPOSITORIES: jeremybanka/dotfiles
         with:
           configurationFile: renovate.json

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -9,6 +9,7 @@ on:
   push:
     branches:
       - main
+      - fix-nix-artifact-update-failure
 
 permissions:
   contents: read
@@ -42,7 +43,7 @@ jobs:
         env:
           LOG_LEVEL: debug
           RENOVATE_ALLOW_PLUGINS: true
-          RENOVATE_ALLOWED_COMMANDS: '["^nix flake lock(?: --update-input (nixpkgs|nixpkgs-unstable)){1,2}$"]'
+          RENOVATE_ALLOWED_COMMANDS: '["^nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update nixpkgs nixpkgs-unstable$"]'
           RENOVATE_REPOSITORIES: jeremybanka/dotfiles
         with:
           configurationFile: renovate.json

--- a/renovate.json
+++ b/renovate.json
@@ -55,13 +55,15 @@
       "matchDepNames": ["nixpkgs", "nixpkgs-unstable"],
       "groupName": "scrubs nix inputs",
       "groupSlug": "scrubs-nix-inputs",
+      "minimumReleaseAge": null,
+      "separateMajorMinor": false,
       "postUpgradeTasks": {
         "commands": [
-          "nix flake lock --update-input nixpkgs --update-input nixpkgs-unstable"
+          "nix --extra-experimental-features nix-command --extra-experimental-features flakes flake update nixpkgs nixpkgs-unstable"
         ],
         "fileFilters": ["vms/flake.lock"],
         "workingDirTemplate": "vms",
-        "executionMode": "update",
+        "executionMode": "branch",
         "installTools": {
           "nix": {}
         }


### PR DESCRIPTION
## Summary
- switch the grouped scrubs Nix update to a `flake update` post-upgrade task that enables the required Nix experimental features
- keep `nixpkgs` and `nixpkgs-unstable` consolidated into one Renovate PR instead of splitting release and digest updates
- clean up the Renovate workflow so it uses the repository config normally and only allows the final Nix artifact command

## Validation
- branch-scoped Renovate runs recreated the Nix update PR successfully after the config changes
- the latest recreated PR was a single `Update scrubs nix inputs` PR with green `Lint` and `Test` checks
- Dependency Dashboard `#811` now shows a single open `Update scrubs nix inputs` entry for the Nix automation path