### PR TITLE
Preserve Codex chat state across bootstrap

### DIFF
--- a/vms/README.md
+++ b/vms/README.md
@@ -393,6 +393,23 @@ just scrubs-auth-delete-codex
 `codex logout` on the host, because the host-side ChatGPT login bundle is the
 source of truth.
 
+Within the guest, scrubs now treats Codex state in two classes:
+
+- durable guest-local Codex state lives in `~/.codex/`, including chat and
+  session history such as `history.jsonl`, `session_index.jsonl`, `sessions/`,
+  and the local SQLite state files
+- ephemeral clean auth lives only in the tmpfs runtime file materialized by the
+  scrubs wrapper, with `~/.codex/auth.json` maintained as a symlink to that
+  runtime file while Codex is launched through the clean wrapper
+
+This preserves guest-local conversation state across `just bootstrap
+<instance>` while keeping the ChatGPT auth bundle out of the durable guest
+Codex home. Existing guests using the older tmpfs-backed `CODEX_HOME` layout
+are migrated automatically the next time the scrubs `codex` wrapper launches:
+the wrapper copies forward non-secret state from the legacy runtime home into
+the durable `~/.codex` directory and continues to source auth from the sealed
+runtime path.
+
 ## Direct Mobile Access
 
 If a Tailscale OAuth client secret is configured for the selected clean auth
@@ -664,12 +681,17 @@ For any new or materially changed guest flow, the baseline pass is:
 1. create a fresh throwaway guest
 2. confirm `limactl shell <instance>` opens an interactive shell
 3. confirm clean-space `gh` and Codex auth are usable without interactive login
-4. confirm dirty-space probes cannot discover `clean-auth`, `gh`, or `codex`
-5. confirm `git credential fill` succeeds for `github.com` through the scrubs helper path
-6. confirm an HTTPS read operation such as `git ls-remote` succeeds
-7. confirm a non-destructive push-shaped probe such as `git push --dry-run` succeeds when the configured token should allow it
-8. run `just bootstrap <instance>` again on that same guest
-9. confirm `limactl shell <instance>` still opens an interactive shell
+4. create a simple Codex continuity marker, for example with `codex exec`, and
+   confirm the resulting guest-local session or history artifact appears under
+   `~/.codex`
+5. confirm dirty-space probes cannot discover `clean-auth`, `gh`, or `codex`
+6. confirm `git credential fill` succeeds for `github.com` through the scrubs helper path
+7. confirm an HTTPS read operation such as `git ls-remote` succeeds
+8. confirm a non-destructive push-shaped probe such as `git push --dry-run` succeeds when the configured token should allow it
+9. run `just bootstrap <instance>` again on that same guest
+10. confirm `limactl shell <instance>` still opens an interactive shell
+11. confirm the prior Codex continuity marker is still present in the durable
+    `~/.codex` state after re-bootstrap
 
 Add the following only when the specific feature or regression under test
 depends on guest-side Tailscale:

--- a/vms/modules/clean-base.nix
+++ b/vms/modules/clean-base.nix
@@ -1,33 +1,4 @@
-{ lib, pkgs, unstablePkgs, ... }:
-let
-  codex = pkgs.stdenvNoCC.mkDerivation rec {
-    pname = "codex";
-    version = "0.130.0";
-
-    src = pkgs.fetchurl {
-      url = "https://github.com/openai/codex/releases/download/rust-v${version}/codex-aarch64-unknown-linux-musl.tar.gz";
-      sha256 = "1d7e00f2c22c3016b5bcb71c61010947b022a90e2901bc6baafe82256492c767";
-    };
-
-    sourceRoot = ".";
-    dontConfigure = true;
-    dontBuild = true;
-
-    installPhase = ''
-      runHook preInstall
-      install -Dm755 codex-aarch64-unknown-linux-musl $out/bin/codex
-      runHook postInstall
-    '';
-
-    meta = with pkgs.lib; {
-      description = "OpenAI's coding agent that runs in your terminal";
-      homepage = "https://github.com/openai/codex";
-      license = licenses.asl20;
-      platforms = [ "aarch64-linux" ];
-      mainProgram = "codex";
-    };
-  };
-in
+{ pkgs, unstablePkgs, ... }:
 {
   nix.settings.experimental-features = [ "nix-command" "flakes" ];
 
@@ -80,7 +51,6 @@ in
   environment.systemPackages = with pkgs; [
     bubblewrap
     carapace
-    codex
     curl
     delta
     fd
@@ -91,6 +61,7 @@ in
     helix
     jq
     lazygit
+    unstablePkgs.codex
     unstablePkgs.mise
     nushell
     openssl

--- a/vms/tasks/closed/0015-preserve-codex-chat-state-across-guest-bootstrap.pug
+++ b/vms/tasks/closed/0015-preserve-codex-chat-state-across-guest-bootstrap.pug
@@ -1,4 +1,4 @@
-issue(id="0015" status="open")
+issue(id="0015" status="closed")
   title Preserve Codex chat state across guest bootstrap
   user-story
     as-a scrubs guest operator using Codex for ongoing work inside a guest
@@ -19,10 +19,24 @@ issue(id="0015" status="open")
     not something that silently drops ongoing Codex context.
 
     The goal of this task is not to abandon the sealed-auth model or move back
-    to plaintext guest auth. The goal is to separate durable, non-secret Codex
-    state such as chats and other local working context from ephemeral auth
-    material, then make sure the standard bootstrap path preserves that durable
-    state on the same guest.
+    to plaintext guest auth. The implemented fix instead separates durable,
+    non-secret Codex state such as chats and local working context from
+    ephemeral auth material, then preserves that durable state across the
+    standard bootstrap path on the same guest.
+
+    This is now settled. Scrubs no longer launches Codex against a synthetic
+    tmpfs-backed `CODEX_HOME` that swallows chat state. The guest's durable
+    `~/.codex` directory remains the real home, the sealed ChatGPT auth bundle
+    is materialized only into tmpfs and linked in as `~/.codex/auth.json`, and
+    the wrapper migrates forward legacy tmpfs-backed Codex state on first
+    launch so existing guests do not need manual repair.
+
+    Validation completed on June 9, 2026. A disposable guest using the updated
+    scrubs wrapper preserved Codex session files across `just bootstrap
+    <instance>`, and a second disposable guest using the unstable-packaged
+    `codex-cli 0.137.0` build successfully resumed the same saved Codex
+    conversation after re-bootstrap and recalled a pre-bootstrap marker from
+    that conversation.
   acceptance-criteria
     criterion A guest that already contains Codex chat history can complete `just bootstrap <instance>` and still show that prior chat state afterward.
     criterion The chosen storage model clearly distinguishes durable guest-local Codex state from ephemeral or sealed auth material, and documents which paths belong to each class.
@@ -30,11 +44,14 @@ issue(id="0015" status="open")
     criterion Repeat-bootstrap validation explicitly includes a Codex continuity smoke test in addition to the existing auth and shell survivability expectations.
     criterion If the current wrapper layout changes, the final design explains how existing guests migrate without forcing operators to manually copy hidden Codex state around after every bootstrap.
   review-items
-    item(status="open").
-      Decide whether Codex should keep using a synthetic runtime `CODEX_HOME`
-      with selective links into durable guest state, or whether only the auth
-      artifact should be overlaid while the primary home stays persistent.
-    item(status="open").
-      Confirm which Codex paths are actually safe to persist across bootstrap
-      and which, if any, should remain ephemeral to avoid credential leakage or
-      wrapper-state confusion.
+    item(status="covered").
+      The chosen model is now explicit: only the sealed auth artifact is
+      overlaid ephemerally, while the primary guest Codex home stays
+      persistent. Scrubs no longer depends on a synthetic runtime `CODEX_HOME`
+      for ordinary guest-local Codex state.
+    item(status="covered").
+      The durable versus ephemeral path split is now documented and validated.
+      Guest-local `~/.codex` state such as sessions, history, and local SQLite
+      files persists across bootstrap, while `~/.codex/auth.json` remains a
+      tmpfs-backed symlink to the runtime ChatGPT auth bundle so credentials do
+      not become part of durable guest state.

--- a/vms/templates/codex-clean.sh
+++ b/vms/templates/codex-clean.sh
@@ -15,24 +15,38 @@ fi
 
 . "${lib_path}"
 
+copy_legacy_runtime_codex_home() {
+  legacy_codex_home="$1"
+  durable_codex_home="$2"
+
+  if [ ! -d "${legacy_codex_home}" ] || [ "${legacy_codex_home}" = "${durable_codex_home}" ]; then
+    return 0
+  fi
+
+  # Migrate prior tmpfs-backed chat/session state forward, but keep auth ephemeral.
+  if ! (cd "${legacy_codex_home}" && tar -cf - --exclude=./auth.json .) \
+    | (cd "${durable_codex_home}" && tar -xf -); then
+    echo "scrubs codex wrapper: failed to migrate legacy runtime Codex state" >&2
+    return 1
+  fi
+}
+
 ciphertext_path="$(scrubs_clean_secret_path codex-auth.json.enc)"
 if ! scrubs_has_clean_secret "${ciphertext_path}"; then
   exec "${real_codex}" "$@"
 fi
 
 runtime_auth_dir="$(scrubs_runtime_auth_dir)"
-runtime_codex_home="${runtime_auth_dir}/codex-home"
-runtime_auth_json="${runtime_codex_home}/auth.json"
-guest_codex_config_dir="${HOME}/.codex"
-guest_codex_config="${guest_codex_config_dir}/config.toml"
+runtime_auth_json="${runtime_auth_dir}/codex-auth.json"
+legacy_runtime_codex_home="${runtime_auth_dir}/codex-home"
+guest_codex_home="${HOME}/.codex"
+guest_auth_json="${guest_codex_home}/auth.json"
 
 umask 077
-mkdir -p "${runtime_codex_home}"
-chmod 700 "${runtime_codex_home}"
+mkdir -p "${guest_codex_home}"
+chmod 700 "${guest_codex_home}"
 
-if [ -f "${guest_codex_config}" ]; then
-  ln -snf "${guest_codex_config}" "${runtime_codex_home}/config.toml"
-fi
+copy_legacy_runtime_codex_home "${legacy_runtime_codex_home}" "${guest_codex_home}"
 
 if ! scrubs_materialize_runtime_secret "${ciphertext_path}" "${runtime_auth_json}"; then
   echo "scrubs codex wrapper: failed to materialize the sealed auth bundle" >&2
@@ -44,4 +58,6 @@ if ! grep -Eq '"auth_mode"[[:space:]]*:[[:space:]]*"chatgpt"' "${runtime_auth_js
   exit 1
 fi
 
-CODEX_HOME="${runtime_codex_home}" exec "${real_codex}" "$@"
+ln -snf "${runtime_auth_json}" "${guest_auth_json}"
+
+exec "${real_codex}" "$@"


### PR DESCRIPTION
## Summary
- preserve durable guest Codex state across scrubs re-bootstrap by keeping `~/.codex` as the real guest home and materializing only ChatGPT auth ephemerally
- migrate legacy tmpfs-backed Codex runtime state into durable guest storage on first wrapper launch, excluding `auth.json`
- switch scrubs guest Codex packaging from the pinned hand-rolled derivation to `unstablePkgs.codex`
- document the durable versus ephemeral Codex state split and add a repeat-bootstrap continuity smoke to the scrubs validation baseline

## Validation
- bootstrapped a disposable guest, verified `codex login status` reported `Logged in using ChatGPT`, created a Codex continuity marker, re-ran `just bootstrap`, and confirmed the marker remained under `~/.codex/sessions` while `~/.codex/auth.json` stayed a tmpfs symlink
- bootstrapped a second disposable guest on the unstable-packaged build and confirmed `codex-cli 0.137.0`
- on that guest, created a saved session containing the marker `REBOOT-RESUME-20260609`, re-bootstrapped the same guest through the normal maintenance flow, then resumed the exact same session with `codex exec resume` and confirmed Codex replied with `REBOOT-RESUME-20260609`
