### PR TITLE
Avoid live-switching fresh scrubs bootstraps

### DIFF
--- a/vms/bootstrap.nu
+++ b/vms/bootstrap.nu
@@ -868,11 +868,6 @@ in
     error make { msg: "Guest did not become reachable over SSH in time." }
   }
 
-  let bootstrap_marker = "/var/lib/scrubs/bootstrap-complete"
-  let already_bootstrapped = (
-    (do { ^ssh ...$ssh_args (remote-shell-command $"test -f \"($bootstrap_marker)\"") } | complete).exit_code == 0
-  )
-
   let bootstrap_home = $"/home/($bootstrap_user)"
   let bootstrap_dir = $"/home/($bootstrap_user)/scrubs-bootstrap"
 
@@ -884,31 +879,29 @@ in
   print "Applying scrubs base configuration inside the guest"
   ^ssh ...$ssh_args (remote-shell-command $"sh \"($bootstrap_dir)/guest-apply.sh\"")
 
-  if $already_bootstrapped {
-    print "Restarting the guest to activate the staged scrubs generation"
-    ^limactl stop $instance_name
-    print $"Lima start can take up to ($start_timeout); waiting for host startup output..."
-    try {
-      ^limactl start --timeout $start_timeout $instance_name
-    } catch {
-      print --stderr $"limactl start did not fully complete within ($start_timeout)."
-      print --stderr "Continuing because scrubs only requires direct SSH reachability after the restart."
-    }
+  print "Restarting the guest to activate the staged scrubs generation"
+  ^limactl stop $instance_name
+  print $"Lima start can take up to ($start_timeout); waiting for host startup output..."
+  try {
+    ^limactl start --timeout $start_timeout $instance_name
+  } catch {
+    print --stderr $"limactl start did not fully complete within ($start_timeout)."
+    print --stderr "Continuing because scrubs only requires direct SSH reachability after the restart."
+  }
 
-    print "Waiting for SSH access to the restarted guest"
-    $ready = false
-    for _ in 0..59 {
-      let ssh_result = (do { ^ssh ...$ssh_args true } | complete)
-      if $ssh_result.exit_code == 0 {
-        $ready = true
-        break
-      }
-      sleep 2sec
+  print "Waiting for SSH access to the restarted guest"
+  $ready = false
+  for _ in 0..59 {
+    let ssh_result = (do { ^ssh ...$ssh_args true } | complete)
+    if $ssh_result.exit_code == 0 {
+      $ready = true
+      break
     }
+    sleep 2sec
+  }
 
-    if not $ready {
-      error make { msg: "Guest did not become reachable over SSH after the restart." }
-    }
+  if not $ready {
+    error make { msg: "Guest did not become reachable over SSH after the restart." }
   }
 
   print ""

--- a/vms/templates/guest-apply.sh
+++ b/vms/templates/guest-apply.sh
@@ -83,31 +83,10 @@ if ! sudo -n true > /dev/null 2>&1; then
   exit 1
 fi
 
-if sudo test -f "$bootstrap_marker"; then
-  if sudo nixos-rebuild boot --flake "$payload/scrubs#scrubs-base"; then
-    exit 0
-  else
-    exit "$?"
-  fi
-fi
-
-if sudo nixos-rebuild switch --flake "$payload/scrubs#scrubs-base"; then
+if sudo nixos-rebuild boot --flake "$payload/scrubs#scrubs-base"; then
   sudo install -d -m 755 "$(dirname "$bootstrap_marker")"
   sudo touch "$bootstrap_marker"
   exit 0
 else
-  status=$?
+  exit "$?"
 fi
-
-if [ "$status" -eq 4 ] && sudo systemctl is-failed --quiet cloud-final.service; then
-  if sudo journalctl -u cloud-final.service -b --no-pager -n 120 | grep -Fq "Runparts: 1 failures"; then
-    echo "cloud-final failed while introducing cloud-init into an older running guest." >&2
-    echo "The new system is active; treating this one-time migration failure as non-fatal." >&2
-    sudo install -d -m 755 "$(dirname "$bootstrap_marker")"
-    sudo touch "$bootstrap_marker"
-    sudo systemctl reset-failed cloud-final.service || true
-    exit 0
-  fi
-fi
-
-exit "$status"


### PR DESCRIPTION
## Summary
- stage scrubs guest changes with `nixos-rebuild boot` instead of live-switching a fresh guest
- always restart the guest after applying the scrubs payload so the staged generation becomes active
- remove the first-boot special case and the old cloud-init switch fallback path

## Why
Fresh instances can start the bootstrap user session before the first rebuild finishes. That left the seed-image user bus running while the new generation tried to reload `dbus-broker.service`, which timed out and caused bootstrap to fail even though the guest configuration was otherwise fine.

## Validation
- `sh -n vms/templates/guest-apply.sh`
- `nu -c source vms/bootstrap.nu`
- user confirmed the bootstrap path worked after this change