### PR TITLE
Restore Darwin-only mise hooks for Nushell

### DIFF
--- a/home/.config/nushell/config.darwin.nu
+++ b/home/.config/nushell/config.darwin.nu
@@ -1,3 +1,5 @@
+use ~/.config/nushell/mise.darwin.nu
+
 $env.config.buffer_editor = "codium"
 
 def c [path: string] {

--- a/home/.config/nushell/mise.darwin.nu
+++ b/home/.config/nushell/mise.darwin.nu
@@ -1,0 +1,57 @@
+def "parse vars" [] {
+  $in | from csv --noheaders --no-infer | rename 'op' 'name' 'value'
+}
+
+def --env "update-env" [] {
+  for $var in $in {
+    if $var.op == "set" {
+      if ($var.name | str upcase) == 'PATH' {
+        $env.PATH = ($var.value | split row (char esep))
+      } else {
+        load-env {($var.name): $var.value}
+      }
+    } else if $var.op == "hide" and $var.name in $env {
+      hide-env $var.name
+    }
+  }
+}
+
+export-env {
+  '' | parse vars | update-env
+  $env.MISE_SHELL = "nu"
+  let mise_hook = {
+    condition: { "MISE_SHELL" in $env }
+    code: { mise_hook }
+  }
+  add-hook hooks.pre_prompt $mise_hook
+  add-hook hooks.env_change.PWD $mise_hook
+}
+
+def --env add-hook [field: cell-path new_hook: any] {
+  let field = $field | split cell-path | update optional true | into cell-path
+  let old_config = $env.config? | default {}
+  let old_hooks = $old_config | get $field | default []
+  $env.config = ($old_config | upsert $field ($old_hooks ++ [$new_hook]))
+}
+
+export def --env --wrapped main [command?: string, --help, ...rest: string] {
+  let commands = ["deactivate", "shell", "sh"]
+
+  if ($command == null) {
+    ^mise
+  } else if ($command == "activate") {
+    $env.MISE_SHELL = "nu"
+  } else if ($command in $commands) {
+    ^mise $command ...$rest
+    | parse vars
+    | update-env
+  } else {
+    ^mise $command ...$rest
+  }
+}
+
+def --env mise_hook [] {
+  ^mise hook-env -s nu
+  | parse vars
+  | update-env
+}


### PR DESCRIPTION
## Summary
- restore Darwin-only Nushell mise hooks under an explicit  name
- keep the Darwin import in  so Scrubs/Linux paths stay untouched
- preserve the cd-driven mise activation behavior for tools like Available recipes:
    audit-instances
    bootstrap instance_name clean_auth_profile="personal" shim_name="" source_image="./vms/images/scrubs.qcow2" tailscale_mode="tailscale-enabled"
    brewfile-dump
    brewfile-use
    default
    download-latest-iso channel="nixos-25.11"
    export-seed-image instance_name output_path
    fmt
    fmt-check
    helix-theme-build output="./build/helix-theme-agent"
    helix-theme-install-agent
    helix-theme-sync
    helix-theme-watch
    helix-watch-config
    lima-ports instance_name=""
    refresh-base-image source_image="./vms/images/scrubs.qcow2" output_path="./vms/images/scrubs.qcow2" instance_name="scrubs-refresh"
    scrubs-auth-delete-codex
    scrubs-auth-delete-gh profile="personal"
    scrubs-auth-delete-tailscale profile=""
    scrubs-auth-set-codex
    scrubs-auth-set-gh profile="personal"
    scrubs-auth-set-tailscale profile=""
    scrubs-auth-status profile=""
    seed instance_name="scrubs-seed"
    sync-base-image-from-icloud image="scrubs.qcow2"
    sync-base-image-to-icloud image="scrubs.qcow2"
    up
    upgrade-workflows
    upgrade-workflows-dry-run
    vm-shell instance_name

## Validation
- started Nushell in home, changed directory to , and confirmed Available recipes:
    audit-instances
    bootstrap instance_name clean_auth_profile="personal" shim_name="" source_image="./vms/images/scrubs.qcow2" tailscale_mode="tailscale-enabled"
    brewfile-dump
    brewfile-use
    default
    download-latest-iso channel="nixos-25.11"
    export-seed-image instance_name output_path
    fmt
    fmt-check
    helix-theme-build output="./build/helix-theme-agent"
    helix-theme-install-agent
    helix-theme-sync
    helix-theme-watch
    helix-watch-config
    lima-ports instance_name=""
    refresh-base-image source_image="./vms/images/scrubs.qcow2" output_path="./vms/images/scrubs.qcow2" instance_name="scrubs-refresh"
    scrubs-auth-delete-codex
    scrubs-auth-delete-gh profile="personal"
    scrubs-auth-delete-tailscale profile=""
    scrubs-auth-set-codex
    scrubs-auth-set-gh profile="personal"
    scrubs-auth-set-tailscale profile=""
    scrubs-auth-status profile=""
    seed instance_name="scrubs-seed"
    sync-base-image-from-icloud image="scrubs.qcow2"
    sync-base-image-to-icloud image="scrubs.qcow2"
    up
    upgrade-workflows
    upgrade-workflows-dry-run
    vm-shell instance_name becomes available
