### PR TITLE
Improve scrubs audit instance version reporting

### DIFF
--- a/vms/audit-instances.nu
+++ b/vms/audit-instances.nu
@@ -3,10 +3,14 @@
 use ./lib.nu *
 
 def short-rev [rev: string] {
-  if ($rev | str length) <= 7 {
-    $rev
+  let trimmed = ($rev | str trim)
+
+  if $trimmed == "" {
+    ""
+  } else if ($trimmed | str length) <= 7 {
+    $trimmed
   } else {
-    $rev | str substring 0..6
+    $trimmed | str substring 0..6
   }
 }
 
@@ -27,36 +31,43 @@ def colorize [text: string, color: string, use_color: bool] {
   }
 }
 
-def plain-width [value: any] {
-  $value | into string | ansi strip | str length
-}
-
-def pad-right [text: string, width: int] {
-  let visible = (plain-width $text)
-  let padding = if $width > $visible { $width - $visible } else { 0 }
-  $text + (" " | fill --character " " --width $padding)
-}
-
-def extract-target-channel [flake_nix: string] {
-  let match = (
-    $flake_nix
-    | parse --regex 'nixpkgs\.url = "github:NixOS/nixpkgs/(?P<ref>[^"]+)";'
-  )
+def extract-input-ref [flake_nix: string, input_name: string, pattern: string] {
+  let match = ($flake_nix | parse --regex $pattern)
 
   if ($match | is-empty) {
-    error make { msg: "Could not determine the current nixpkgs ref from vms/flake.nix." }
+    error make { msg: $"Could not determine the current ($input_name) ref from vms/flake.nix." }
   }
 
-  let ref = ($match | first | get ref)
-  let channel = if ($ref | str starts-with "nixos-") {
+  $match | first | get ref
+}
+
+def normalize-release-channel [ref: string] {
+  if ($ref | str starts-with "nixos-") {
     $ref | str replace --regex '^nixos-' ""
   } else {
     $ref
   }
+}
 
-  {
-    ref: $ref
-    channel: $channel
+def format-version-cell [guest_value: string, target_value: string, use_color: bool] {
+  if $guest_value == "-" {
+    colorize "-" "dark_gray" $use_color
+  } else if $guest_value == "" and $target_value == "" {
+    colorize "-" "dark_gray" $use_color
+  } else if $guest_value == "" {
+    colorize $"unknown -> ($target_value)" "cyan_bold" $use_color
+  } else if $target_value == "" or $guest_value == $target_value {
+    colorize $guest_value "green" $use_color
+  } else {
+    colorize $"($guest_value) -> ($target_value)" "yellow_bold" $use_color
+  }
+}
+
+def join-notes [parts: list<string>] {
+  if ($parts | is-empty) {
+    ""
+  } else {
+    $parts | str join "; "
   }
 }
 
@@ -64,15 +75,21 @@ def load-target [] {
   let vms_root = (vms-dir)
   let flake_nix = (open --raw ($vms_root | path join "flake.nix"))
   let flake_lock = (open --raw ($vms_root | path join "flake.lock") | from json)
-  let channel_info = (extract-target-channel $flake_nix)
-  let rev = ($flake_lock.nodes.nixpkgs.locked.rev | default "")
+  let nixpkgs_ref = (extract-input-ref $flake_nix "nixpkgs" 'nixpkgs\.url = "github:NixOS/nixpkgs/(?P<ref>[^"]+)";')
+  let nixpkgs_unstable_ref = (
+    extract-input-ref $flake_nix "nixpkgs-unstable" 'nixpkgs-unstable\.url = "github:NixOS/nixpkgs/(?P<ref>[^"]+)";'
+  )
+  let nixpkgs_revision = ($flake_lock.nodes.nixpkgs.locked.rev | default "")
+  let nixpkgs_unstable_revision = ($flake_lock.nodes."nixpkgs-unstable".locked.rev | default "")
 
   {
-    ref: $channel_info.ref
-    channel: $channel_info.channel
-    rev: $rev
-    short_rev: (short-rev $rev)
-    label: $"($channel_info.channel) @ (short-rev $rev)"
+    nixos_release: (normalize-release-channel $nixpkgs_ref)
+    nixpkgs_ref: $nixpkgs_ref
+    nixpkgs_revision: $nixpkgs_revision
+    nixpkgs_short_revision: (short-rev $nixpkgs_revision)
+    nixpkgs_unstable_ref: $nixpkgs_unstable_ref
+    nixpkgs_unstable_revision: $nixpkgs_unstable_revision
+    nixpkgs_unstable_short_revision: (short-rev $nixpkgs_unstable_revision)
   }
 }
 
@@ -102,7 +119,7 @@ def maybe-get [record: any, path: cell-path, fallback: any = ""] {
   }
 }
 
-def normalize-guest-info [stdout: string] {
+def normalize-guest-version-info [stdout: string] {
   let trimmed = ($stdout | str trim)
 
   if $trimmed == "" {
@@ -113,7 +130,14 @@ def normalize-guest-info [stdout: string] {
   }
 
   if ($trimmed | str starts-with "{") {
-    let parsed = ($trimmed | from json)
+    let parsed = (try { $trimmed | from json } catch { null })
+    if $parsed == null {
+      return {
+        ok: false
+        reason: "guest version response was not valid JSON"
+      }
+    }
+
     let nixos_version = (
       (maybe-get $parsed nixosVersion "")
       | default (maybe-get $parsed nixos-version "")
@@ -146,7 +170,7 @@ def normalize-guest-info [stdout: string] {
   }
 }
 
-def probe-instance [instance_name: string] {
+def probe-guest-version [instance_name: string] {
   let result = (
     do {
       ^limactl shell $instance_name -- sh -lc "nixos-version --json 2>/dev/null || nixos-version"
@@ -166,7 +190,120 @@ def probe-instance [instance_name: string] {
     }
   }
 
-  normalize-guest-info $result.stdout
+  normalize-guest-version-info $result.stdout
+}
+
+def probe-guest-lock [instance_name: string] {
+  let result = (
+    do {
+      ^limactl shell $instance_name -- sh -lc 'cat "$HOME/scrubs-bootstrap/scrubs/flake.lock" 2>/dev/null'
+    } | complete
+  )
+
+  if $result.exit_code != 0 {
+    return {
+      ok: false
+      reason: (
+        $result.stderr
+        | str trim
+        | lines
+        | last
+        | default "could not read guest flake.lock"
+      )
+    }
+  }
+
+  let trimmed = ($result.stdout | str trim)
+  if $trimmed == "" {
+    return {
+      ok: false
+      reason: 'missing ~/scrubs-bootstrap/scrubs/flake.lock'
+    }
+  }
+
+  let parsed = (try { $trimmed | from json } catch { null })
+  if $parsed == null {
+    return {
+      ok: false
+      reason: "guest flake.lock was not valid JSON"
+    }
+  }
+
+  {
+    ok: true
+    nixpkgs_revision: (try { $parsed.nodes.nixpkgs.locked.rev | into string } catch { "" })
+    nixpkgs_unstable_revision: (try { $parsed.nodes."nixpkgs-unstable".locked.rev | into string } catch { "" })
+  }
+}
+
+def probe-instance [instance_name: string] {
+  let version_probe = (probe-guest-version $instance_name)
+  if not $version_probe.ok {
+    return $version_probe
+  }
+
+  let lock_probe = (probe-guest-lock $instance_name)
+  let running_nixpkgs_revision = ($version_probe.nixpkgs_revision | default "")
+  let lock_nixpkgs_revision = if $lock_probe.ok { $lock_probe.nixpkgs_revision | default "" } else { "" }
+  let trusted_lock = (
+    $lock_probe.ok
+    and $lock_nixpkgs_revision != ""
+    and (
+      $running_nixpkgs_revision == ""
+      or $lock_nixpkgs_revision == $running_nixpkgs_revision
+    )
+  )
+  let metadata_notes = (
+    [
+      (
+        if (not $lock_probe.ok) {
+          $lock_probe.reason
+        } else {
+          null
+        }
+      )
+      (
+        if (
+          $lock_probe.ok
+          and $running_nixpkgs_revision != ""
+          and $lock_nixpkgs_revision != ""
+          and $running_nixpkgs_revision != $lock_nixpkgs_revision
+        ) {
+          $"guest flake.lock does not match running nixpkgs: (short-rev $lock_nixpkgs_revision) vs (short-rev $running_nixpkgs_revision)"
+        } else {
+          null
+        }
+      )
+      (
+        if $trusted_lock and (($lock_probe.nixpkgs_unstable_revision | default "") == "") {
+          "guest flake.lock did not include a nixpkgs-unstable revision"
+        } else {
+          null
+        }
+      )
+    ]
+    | where {|item| $item != null }
+    | each {|item| $item | into string }
+  )
+  let nixpkgs_revision = if $running_nixpkgs_revision != "" {
+    $running_nixpkgs_revision
+  } else {
+    $lock_nixpkgs_revision
+  }
+  let nixpkgs_unstable_revision = if $trusted_lock {
+    $lock_probe.nixpkgs_unstable_revision | default ""
+  } else {
+    ""
+  }
+
+  {
+    ok: true
+    nixos_version: ($version_probe.nixos_version | default "")
+    nixos_release: (extract-version-channel ($version_probe.nixos_version | default ""))
+    nixpkgs_revision: $nixpkgs_revision
+    nixpkgs_unstable_revision: $nixpkgs_unstable_revision
+    metadata_note: (join-notes $metadata_notes)
+  }
 }
 
 def classify-instance [instance: record, target: record] {
@@ -178,10 +315,11 @@ def classify-instance [instance: record, target: record] {
       instance: $name
       lima_state: $state
       assessment: "stopped"
-      target: $target.label
-      guest: "-"
+      nixos_release: "-"
+      nixpkgs: "-"
+      nixpkgs_unstable: "-"
       note: "not running; cannot assess"
-      sort_rank: 3
+      sort_rank: 4
     }
   }
 
@@ -191,67 +329,138 @@ def classify-instance [instance: record, target: record] {
       instance: $name
       lima_state: $state
       assessment: "unreachable"
-      target: $target.label
-      guest: "unknown"
+      nixos_release: "-"
+      nixpkgs: "-"
+      nixpkgs_unstable: "-"
       note: $probe.reason
-      sort_rank: 2
+      sort_rank: 3
     }
   }
 
-  let guest_version = ($probe.nixos_version | default "unknown")
-  let guest_channel = (extract-version-channel $guest_version)
-  let guest_rev = ($probe.nixpkgs_revision | default "")
-  let guest_short_rev = if $guest_rev == "" { "" } else { short-rev $guest_rev }
-  let guest_label = if $guest_short_rev == "" {
-    $guest_version
+  let guest_release = ($probe.nixos_release | default "")
+  let guest_nixpkgs_revision = ($probe.nixpkgs_revision | default "")
+  let guest_nixpkgs_unstable_revision = ($probe.nixpkgs_unstable_revision | default "")
+  let guest_nixpkgs_short_revision = (short-rev $guest_nixpkgs_revision)
+  let guest_nixpkgs_unstable_short_revision = (short-rev $guest_nixpkgs_unstable_revision)
+  let drift_notes = (
+    [
+      (
+        if $guest_release != "" and $guest_release != $target.nixos_release {
+          $"nixos release: ($guest_release) -> ($target.nixos_release)"
+        } else {
+          null
+        }
+      )
+      (
+        if (
+          $guest_nixpkgs_short_revision != ""
+          and $guest_nixpkgs_short_revision != $target.nixpkgs_short_revision
+        ) {
+          $"nixpkgs: ($guest_nixpkgs_short_revision) -> ($target.nixpkgs_short_revision)"
+        } else {
+          null
+        }
+      )
+      (
+        if (
+          $guest_nixpkgs_unstable_short_revision != ""
+          and $guest_nixpkgs_unstable_short_revision != $target.nixpkgs_unstable_short_revision
+        ) {
+          $"nixpkgs-unstable: ($guest_nixpkgs_unstable_short_revision) -> ($target.nixpkgs_unstable_short_revision)"
+        } else {
+          null
+        }
+      )
+    ]
+    | where {|item| $item != null }
+    | each {|item| $item | into string }
+  )
+  let missing_notes = (
+    [
+      (
+        if $guest_release == "" {
+          "missing nixos release"
+        } else {
+          null
+        }
+      )
+      (
+        if $guest_nixpkgs_short_revision == "" {
+          "missing nixpkgs revision"
+        } else {
+          null
+        }
+      )
+      (
+        if $guest_nixpkgs_unstable_short_revision == "" {
+          "missing nixpkgs-unstable revision"
+        } else {
+          null
+        }
+      )
+    ]
+    | where {|item| $item != null }
+    | each {|item| $item | into string }
+  )
+  let note_parts = (
+    [
+      (
+        if not ($drift_notes | is-empty) {
+          join-notes $drift_notes
+        } else {
+          null
+        }
+      )
+      (
+        if (
+          ($drift_notes | is-empty)
+          and not ($missing_notes | is-empty)
+        ) {
+          join-notes $missing_notes
+        } else {
+          null
+        }
+      )
+      (
+        if ($probe.metadata_note | default "") != "" {
+          $probe.metadata_note
+        } else {
+          null
+        }
+      )
+    ]
+    | where {|item| $item != null }
+    | each {|item| $item | into string }
+  )
+  let assessment = if not ($drift_notes | is-empty) {
+    "stale"
+  } else if not ($missing_notes | is-empty) {
+    "unknown"
   } else {
-    $"($guest_version) @ ($guest_short_rev)"
+    "current"
   }
-
-  if $guest_channel != "" and $guest_channel != $target.channel {
-    return {
-      instance: $name
-      lima_state: $state
-      assessment: "stale"
-      target: $target.label
-      guest: $guest_label
-      note: $"branch drift: ($guest_channel) -> ($target.channel)"
-      sort_rank: 1
-    }
-  }
-
-  if $guest_channel == $target.channel and $guest_rev != "" and $guest_rev != $target.rev {
-    return {
-      instance: $name
-      lima_state: $state
-      assessment: "current"
-      target: $target.label
-      guest: $guest_label
-      note: $"on target release line; revision differs: ($guest_short_rev) vs ($target.short_rev)"
-      sort_rank: 0
-    }
-  }
-
-  if $guest_channel == $target.channel or ($guest_rev != "" and $guest_rev == $target.rev) {
-    return {
-      instance: $name
-      lima_state: $state
-      assessment: "current"
-      target: $target.label
-      guest: $guest_label
-      note: "up to date"
-      sort_rank: 0
-    }
+  let sort_rank = match $assessment {
+    "stale" => 0
+    "unknown" => 1
+    "current" => 2
+    _ => 2
   }
 
   {
     instance: $name
     lima_state: $state
-    assessment: "stale"
-    target: $target.label
-    guest: $guest_label
-    note: $"branch drift: ($guest_version) -> ($target.channel)"
-    sort_rank: 1
+    assessment: $assessment
+    nixos_release: $guest_release
+    nixpkgs: $guest_nixpkgs_short_revision
+    nixpkgs_unstable: $guest_nixpkgs_unstable_short_revision
+    note: (
+      if ($note_parts | is-empty) {
+        "up to date"
+      } else {
+        join-notes $note_parts
+      }
+    )
+    sort_rank: $sort_rank
   }
 }
 
@@ -259,89 +468,27 @@ def style-assessment [assessment: string, use_color: bool] {
   match $assessment {
     "current" => (colorize "CURRENT" "green_bold" $use_color)
     "stale" => (colorize "STALE" "yellow_bold" $use_color)
+    "unknown" => (colorize "UNKNOWN" "cyan_bold" $use_color)
     "unreachable" => (colorize "UNREACHABLE" "red_bold" $use_color)
     "stopped" => (colorize "STOPPED" "dark_gray" $use_color)
     _ => (colorize ($assessment | str upcase) "light_gray" $use_color)
   }
 }
 
-def render-summary [rows: table, target: record, use_color: bool] {
-  let current_count = ($rows | where assessment == "current" | length)
-  let stale_count = ($rows | where assessment == "stale" | length)
-  let unreachable_count = ($rows | where assessment == "unreachable" | length)
-  let stopped_count = ($rows | where assessment == "stopped" | length)
-  let total = ($rows | length)
-  let target_label = (colorize $target.label "cyan_bold" $use_color)
-  let current_label = (colorize ($current_count | into string) "green_bold" $use_color)
-  let stale_label = (colorize ($stale_count | into string) "yellow_bold" $use_color)
-  let unreachable_label = (colorize ($unreachable_count | into string) "red_bold" $use_color)
-  let stopped_label = (colorize ($stopped_count | into string) "dark_gray" $use_color)
-
-  print $"scrubs target: ($target_label)"
-  print $"instances: ($total)  current: ($current_label)  stale: ($stale_label)  unreachable: ($unreachable_label)  stopped: ($stopped_label)"
-  print ""
-}
-
-def render-table [rows: table, use_color: bool] {
-  let display_rows = (
-    $rows
-    | sort-by sort_rank instance
-    | each {|row|
-        {
-          status: (style-assessment $row.assessment $use_color)
-          instance: $row.instance
-          lima: $row.lima_state
-          guest: $row.guest
-          target: $row.target
-          note: $row.note
-        }
+def render-table [rows: table, target: record, use_color: bool] {
+  $rows
+  | sort-by sort_rank instance
+  | each {|row|
+      {
+        status: (style-assessment $row.assessment $use_color)
+        instance: $row.instance
+        lima: $row.lima_state
+        nixos_release: (format-version-cell $row.nixos_release $target.nixos_release $use_color)
+        nixpkgs: (format-version-cell $row.nixpkgs $target.nixpkgs_short_revision $use_color)
+        nixpkgs_unstable: (format-version-cell $row.nixpkgs_unstable $target.nixpkgs_unstable_short_revision $use_color)
+        note: $row.note
       }
-  )
-
-  let columns = [
-    { key: "status", header: "STATUS" }
-    { key: "instance", header: "INSTANCE" }
-    { key: "lima", header: "LIMA" }
-    { key: "guest", header: "GUEST NIXOS" }
-    { key: "target", header: "TARGET" }
-    { key: "note", header: "NOTE" }
-  ]
-
-  let widths = (
-    $columns
-    | each {|column|
-        let cell_width = (
-          $display_rows
-          | each {|row| plain-width ($row | get $column.key) }
-          | append (plain-width $column.header)
-          | math max
-        )
-        { key: $column.key, width: $cell_width }
-      }
-  )
-
-  let header = (
-    $columns
-    | each {|column|
-        let width = ($widths | where key == $column.key | first | get width)
-        pad-right $column.header $width
-      }
-    | str join "  "
-  )
-
-  print (colorize $header "blue_bold" $use_color)
-
-  for row in $display_rows {
-    let rendered = (
-      $columns
-      | each {|column|
-          let width = ($widths | where key == $column.key | first | get width)
-          pad-right ($row | get $column.key | into string) $width
-        }
-      | str join "  "
-    )
-    print $rendered
-  }
+    }
 }
 
 def main [
@@ -357,6 +504,5 @@ def main [
   }
 
   let rows = ($instances | each {|instance| classify-instance $instance $target })
-  render-summary $rows $target $use_color
-  render-table $rows $use_color
+  render-table $rows $target $use_color
 }


### PR DESCRIPTION
## Summary
- return a native Nushell table from `audit-instances`
- compare NixOS release, `nixpkgs`, and `nixpkgs-unstable` separately
- mark incomplete guest metadata as `UNKNOWN` instead of looking current

## Testing
- `nu -n -c 'source /Users/jem/dotfiles/vms/audit-instances.nu'`
- `nu /Users/jem/dotfiles/vms/audit-instances.nu --no-color`