### PR TITLE
🔧 stabilize custom nix Renovate updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -14,8 +14,9 @@
       "customType": "regex",
       "managerFilePatterns": ["/^vms\\/flake\\.nix$/"],
       "matchStrings": [
-        "(?<depName>nixpkgs(?:-unstable)?)\\.url\\s*=\\s*\"github:NixOS\\/nixpkgs\\/(?<currentValue>[^\"]+)\";"
+        "nixpkgs\\.url\\s*=\\s*\"github:NixOS\\/nixpkgs\\/(?<currentValue>[^\"]+)\";"
       ],
+      "depNameTemplate": "scrubs-nixpkgs-release",
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/NixOS/nixpkgs",
       "versioningTemplate": "nixpkgs"
@@ -24,8 +25,20 @@
       "customType": "regex",
       "managerFilePatterns": ["/^vms\\/flake\\.lock$/"],
       "matchStrings": [
-        "\"(?<depName>nixpkgs(?:-unstable)?)\":\\s*\\{\\s*\"locked\":\\s*\\{[\\s\\S]*?\"rev\":\\s*\"(?<currentDigest>[a-f0-9]{40})\"[\\s\\S]*?\\}\\s*,\\s*\"original\":\\s*\\{[\\s\\S]*?\"ref\":\\s*\"(?<currentValue>[^\"]+)\""
+        "\"nixpkgs\":\\s*\\{\\s*\"locked\":\\s*\\{[\\s\\S]*?\"rev\":\\s*\"(?<currentDigest>[a-f0-9]{40})\"[\\s\\S]*?\\}\\s*,\\s*\"original\":\\s*\\{[\\s\\S]*?\"ref\":\\s*\"(?<currentValue>[^\"]+)\""
       ],
+      "depNameTemplate": "scrubs-nixpkgs-digest",
+      "datasourceTemplate": "git-refs",
+      "packageNameTemplate": "https://github.com/NixOS/nixpkgs",
+      "versioningTemplate": "exact"
+    },
+    {
+      "customType": "regex",
+      "managerFilePatterns": ["/^vms\\/flake\\.lock$/"],
+      "matchStrings": [
+        "\"nixpkgs-unstable\":\\s*\\{\\s*\"locked\":\\s*\\{[\\s\\S]*?\"rev\":\\s*\"(?<currentDigest>[a-f0-9]{40})\"[\\s\\S]*?\\}\\s*,\\s*\"original\":\\s*\\{[\\s\\S]*?\"ref\":\\s*\"(?<currentValue>[^\"]+)\""
+      ],
+      "depNameTemplate": "scrubs-nixpkgs-unstable-digest",
       "datasourceTemplate": "git-refs",
       "packageNameTemplate": "https://github.com/NixOS/nixpkgs",
       "versioningTemplate": "exact"
@@ -52,7 +65,11 @@
     },
     {
       "matchManagers": ["custom.regex"],
-      "matchDepNames": ["nixpkgs", "nixpkgs-unstable"],
+      "matchDepNames": [
+        "scrubs-nixpkgs-release",
+        "scrubs-nixpkgs-digest",
+        "scrubs-nixpkgs-unstable-digest"
+      ],
       "groupName": "scrubs nix inputs",
       "groupSlug": "scrubs-nix-inputs",
       "minimumReleaseAge": null,


### PR DESCRIPTION
## Summary
Split our custom Nix Renovate handling into distinct dependencies:
- stable release branch tracking from `vms/flake.nix`
- stable digest tracking from `vms/flake.lock`
- unstable digest tracking from `vms/flake.lock`

## Why
We found that the same logical `nixpkgs` dependency was being represented in both `flake.nix` and `flake.lock`, and Renovate was intermittently flattening those updates incorrectly. In one run it missed a real stable digest update; in a later run it found it and opened the PR.

This keeps our local custom implementation but removes the overlap that was making detection brittle.

It also matches the Nixpkgs release model better:
- `nixos-26.05` is a moving release branch name worth tracking in `flake.nix`
- `nixpkgs-unstable` is a moving ref whose meaningful update is the locked commit in `flake.lock`

## Validation
- confirmed upstream `nixpkgs-unstable` had not advanced during the five-day gap
- confirmed upstream `nixos-26.05` had advanced and `nix flake update nixpkgs` picked it up
- validated the updated regex managers against current `vms/flake.nix` and `vms/flake.lock`
- validated `renovate.json` parses cleanly
