### PR TITLE
feat(scrubs): add headless browser automation

### DIFF
--- a/vms/README.md
+++ b/vms/README.md
@@ -85,6 +85,7 @@ keeping the VM isolation model intact.
 - your `mise` config
 - clean shells that stay Nix-first while `mise`-backed tools are proxied through the scrubs dirty-runtime launcher
 - optional sealed clean-auth wrappers for `gh` and `codex` when host secrets are configured
+- a pinned, headless Playwright MCP browser for Codex tasks
 - a writable `mise` cache under `/tmp` so sandboxed commands stay quiet
 - `git`, `nushell`, `mise`, `bun`, `codex`, and common CLI utilities
 - hardened SSH defaults inside the guest
@@ -438,6 +439,36 @@ the wrapper copies forward non-secret state from the legacy runtime home into
 the durable `~/.codex` directory and continues to source auth from the sealed
 runtime path.
 
+## Browser Automation For Codex
+
+Every scrubs guest configures a required `playwright` STDIO MCP server in the
+durable user-level `~/.codex/config.toml`. Codex requests remote executor
+placement for the server, so a worker-side Codex environment starts the MCP
+process in the guest rather than on the controlling desktop. The server and
+its compatible Chromium revision come from the guest's pinned nixpkgs lock;
+there are no runtime npm or browser downloads.
+
+The server's tools are pre-approved in Codex. This is necessary for unattended
+tasks because Playwright annotates navigation and interaction as side-effecting,
+while non-interactive Codex tasks use an approval policy that cannot prompt a
+user. The pre-approval is limited to this isolated, credential-free browser;
+it does not relax shell, filesystem, or other MCP approvals.
+
+The configured command is `codex-playwright-mcp`. It launches Playwright
+headlessly with isolated browser state and Chromium's sandbox enabled. A
+second bubblewrap boundary gives the MCP server and browser a synthetic home,
+private `/tmp` and `/dev/shm`, the current project worktree, a narrow Nix-store
+runtime closure, and no view of `~/.codex`, `~/.ssh`, or the scrubs clean-auth
+surface. The wrapper deliberately does not unshare the network namespace, so a
+browser task can reach a dirty-space development server through guest-local
+addresses such as `http://127.0.0.1:4321` without exposing clean credentials
+to the browser process.
+
+Use `codex mcp get playwright` in the guest to inspect the configuration, or
+`/mcp` in a fresh Codex task to confirm that the server connected. The MCP
+exposes accessibility snapshots, navigation, clicking and typing,
+screenshots, console messages, and network requests.
+
 ## Direct Mobile Access
 
 If a Tailscale OAuth client secret is configured for the selected clean auth
@@ -714,14 +745,17 @@ For any new or materially changed guest flow, the baseline pass is:
    confirm the resulting guest-local session or history artifact appears under
    `~/.codex`
 5. confirm dirty-space probes cannot discover `clean-auth`, `gh`, or `codex`
-6. confirm `git credential fill` succeeds for `github.com` through the scrubs helper path
-7. confirm an HTTPS read operation such as `git ls-remote` succeeds
-8. confirm a non-destructive push-shaped probe such as `git push --dry-run` succeeds when the configured token should allow it
-9. run `just bootstrap <instance>` again on that same guest
-10. confirm `limactl shell <instance>` still opens an interactive shell
-11. confirm the prior Codex continuity marker is still present in the durable
+6. confirm `codex mcp get playwright` reports the worker-side Playwright MCP
+7. confirm the browser can reach a dirty-space development server through
+   `http://127.0.0.1:<port>` and can capture a snapshot and screenshot
+8. confirm `git credential fill` succeeds for `github.com` through the scrubs helper path
+9. confirm an HTTPS read operation such as `git ls-remote` succeeds
+10. confirm a non-destructive push-shaped probe such as `git push --dry-run` succeeds when the configured token should allow it
+11. run `just bootstrap <instance>` again on that same guest
+12. confirm `limactl shell <instance>` still opens an interactive shell
+13. confirm the prior Codex continuity marker is still present in the durable
     `~/.codex` state after re-bootstrap
-12. from inside a guest project workspace, confirm happy-path Linux runtime
+14. from inside a guest project workspace, confirm happy-path Linux runtime
     probes such as `nu -c 'print ok'`, `node -v`, `ni --version`, and
     `rg --version` still work through the scrubs runtime path
 

--- a/vms/configuration.nix
+++ b/vms/configuration.nix
@@ -8,6 +8,7 @@ in
 {
   imports = [
     ./modules/clean-base.nix
+    ./modules/clean-playwright.nix
   ]
   ++ (if builtins.pathExists tailscaleConfigModule then [ tailscaleConfigModule ] else [ ])
   ++ (if builtins.pathExists projectShimModule then [ projectShimModule ] else [ ])

--- a/vms/modules/clean-playwright.nix
+++ b/vms/modules/clean-playwright.nix
@@ -1,0 +1,142 @@
+{ pkgs, ... }:
+let
+  # Keep the Playwright browser closure to Chromium while preserving the exact
+  # browser revision paired with the pinned nixpkgs Playwright driver.
+  playwrightBrowsers = pkgs.playwright-driver.selectBrowsers {
+    withFirefox = false;
+    withWebkit = false;
+  };
+  playwrightDriver = pkgs.playwright-driver // {
+    browsers = playwrightBrowsers;
+  };
+  playwrightTest = pkgs.playwright-test.overrideAttrs (oldAttrs: {
+    postFixup = (oldAttrs.postFixup or "") + ''
+      substituteInPlace $out/bin/playwright \
+        --replace-fail '${pkgs.playwright-driver.browsers}' '${playwrightBrowsers}'
+    '';
+  });
+  playwrightMcp = pkgs.playwright-mcp.override {
+    playwright-driver = playwrightDriver;
+    playwright-test = playwrightTest;
+  };
+
+  browserRuntimeClosure = pkgs.closureInfo {
+    rootPaths = [
+      playwrightMcp
+      pkgs.coreutils
+      pkgs.file
+      pkgs.glibc.bin
+      pkgs.gnugrep
+      pkgs.gnused
+      pkgs.which
+    ];
+  };
+
+  codexPlaywrightMcp = pkgs.writeShellApplication {
+    name = "codex-playwright-mcp";
+    runtimeInputs = [
+      pkgs.bubblewrap
+      pkgs.coreutils
+      pkgs.git
+    ];
+    text = ''
+      current_user="$(id -un)"
+      current_uid="$(id -u)"
+      real_home="''${HOME:-/home/$current_user}"
+      working_dir="$(pwd -P)"
+      workspace_root="$(${pkgs.git}/bin/git -C "$working_dir" rev-parse --show-toplevel 2>/dev/null || true)"
+
+      if [[ -z "$workspace_root" ]]; then
+        workspace_root="$working_dir"
+      fi
+
+      # Never project the real home or a known clean credential surface into
+      # the browser sandbox. Codex can still start from those locations, but
+      # Playwright receives only its empty synthetic home in that case.
+      case "$workspace_root" in
+        /|"$real_home"|"$real_home/.codex"|"$real_home/.codex/"*|"$real_home/.ssh"|"$real_home/.ssh/"*|"$real_home/.local/share/scrubs"|"$real_home/.local/share/scrubs/"*)
+          workspace_root=""
+          ;;
+      esac
+
+      runtime_parent="''${XDG_RUNTIME_DIR:-/tmp}/scrubs-playwright-mcp-$current_uid"
+      install -d -m 700 "$runtime_parent"
+      runtime_dir="$(mktemp -d "$runtime_parent/session.XXXXXXXX")"
+      trap 'rm -rf "$runtime_dir"' EXIT INT TERM
+
+      fake_home="$runtime_dir/home"
+      mkdir -p "$fake_home"
+      chmod 700 "$fake_home"
+
+      declare -a store_binds=()
+      while IFS= read -r store_path; do
+        [[ -n "$store_path" ]] || continue
+        store_binds+=(--ro-bind "$store_path" "$store_path")
+      done < ${browserRuntimeClosure}/store-paths
+
+      declare -a workspace_bind=()
+      sandbox_working_dir="/home/$current_user"
+      if [[ -n "$workspace_root" ]]; then
+        workspace_bind=(--bind "$workspace_root" "$workspace_root")
+        sandbox_working_dir="$working_dir"
+      fi
+
+      sandbox_path="${pkgs.coreutils}/bin:${pkgs.file}/bin:${pkgs.glibc.bin}/bin:${pkgs.gnugrep}/bin:${pkgs.gnused}/bin:${pkgs.which}/bin"
+
+      exec ${pkgs.bubblewrap}/bin/bwrap \
+        --die-with-parent \
+        --new-session \
+        --clearenv \
+        --unshare-user \
+        --unshare-ipc \
+        --unshare-pid \
+        --unshare-uts \
+        --unshare-cgroup-try \
+        --tmpfs / \
+        --proc /proc \
+        --dev /dev \
+        --dir /dev/shm \
+        --tmpfs /dev/shm \
+        --tmpfs /tmp \
+        --dir /nix \
+        --dir /nix/store \
+        --dir /etc \
+        --dir /etc/ssl \
+        --dir /etc/ssl/certs \
+        --ro-bind /etc/passwd /etc/passwd \
+        --ro-bind /etc/group /etc/group \
+        --ro-bind /etc/nsswitch.conf /etc/nsswitch.conf \
+        --ro-bind /etc/hosts /etc/hosts \
+        --ro-bind /etc/resolv.conf /etc/resolv.conf \
+        --ro-bind /etc/localtime /etc/localtime \
+        --ro-bind /etc/ssl/certs/ca-bundle.crt /etc/ssl/certs/ca-bundle.crt \
+        --dir /home \
+        --dir "/home/$current_user" \
+        --bind "$fake_home" "/home/$current_user" \
+        "''${workspace_bind[@]}" \
+        "''${store_binds[@]}" \
+        --chdir "$sandbox_working_dir" \
+        --setenv HOME "/home/$current_user" \
+        --setenv USER "$current_user" \
+        --setenv LOGNAME "$current_user" \
+        --setenv PATH "$sandbox_path" \
+        --setenv PWD "$sandbox_working_dir" \
+        --setenv SHELL ${pkgs.bash}/bin/bash \
+        --setenv TMPDIR /tmp \
+        --setenv XDG_CACHE_HOME /tmp/cache \
+        --setenv XDG_CONFIG_HOME /tmp/config \
+        --setenv XDG_RUNTIME_DIR /tmp/runtime \
+        --setenv SSL_CERT_FILE /etc/ssl/certs/ca-bundle.crt \
+        -- \
+        ${playwrightMcp}/bin/playwright-mcp \
+          --headless \
+          --isolated \
+          --sandbox \
+          --output-dir "/home/$current_user/.playwright-mcp" \
+          "$@"
+    '';
+  };
+in
+{
+  environment.systemPackages = [ codexPlaywrightMcp ];
+}

--- a/vms/tasks/review/0020-support-headless-browser-automation-for-codex.pug
+++ b/vms/tasks/review/0020-support-headless-browser-automation-for-codex.pug
@@ -1,0 +1,49 @@
+issue(id="0020" status="review")
+  title Support headless browser automation for Codex in scrubs guests
+  user-story
+    as-a Codex agent running in a remote scrubs guest
+    i-want a pinned worker-side browser tool that can inspect and interact with local development servers
+    so-that I can validate rendered applications at guest-local addresses without runtime downloads or access to clean credentials
+  premise.
+    Codex tasks in scrubs need browser navigation, accessibility snapshots,
+    clicking and typing, screenshots, console inspection, and network
+    inspection against services such as `127.0.0.1:4321`. The browser must run
+    in the worker network namespace, but it must not turn the clean Codex
+    process into a bridge from untrusted web content to sealed auth or other
+    clean-home state.
+  acceptance-criteria
+    criterion A fresh Codex task reports the Playwright MCP server as connected and exposes navigation, interaction, snapshot, screenshot, console, and network tools.
+    criterion The Playwright MCP package and compatible Chromium revision are pinned by the scrubs Nix flake, with no runtime npm or browser downloads.
+    criterion The MCP server and Chromium run headlessly with isolated state, writable temporary storage, private shared memory, and Chromium's sandbox enabled.
+    criterion The browser process cannot see the real guest home, Codex state, SSH state, or scrubs clean-auth surface.
+    criterion The browser shares the guest network namespace and can reach a dirty-space development server through `http://127.0.0.1:4321`.
+  review-items
+    item(status="covered").
+      The pinned nixpkgs `playwright-mcp` package provides the MCP server and
+      its matching Playwright browser build. The scrubs package override keeps
+      the browser farm to Chromium and Chromium headless shell rather than
+      carrying Firefox and WebKit into every guest.
+    item(status="covered").
+      `codex-playwright-mcp` runs the MCP server and browser inside a dedicated
+      bubblewrap boundary with a synthetic home, private `/tmp` and `/dev/shm`,
+      a narrow Nix closure, and only the active project worktree. It preserves
+      the guest network namespace and explicitly enables Chromium's sandbox.
+    item(status="covered").
+      Bootstrap converges a required `playwright` STDIO server in the durable
+      Codex config with remote executor placement and explicit startup and
+      tool timeouts while preserving unrelated user configuration. Its tools
+      are pre-approved specifically for this isolated, credential-free browser
+      so unattended Codex tasks can use Playwright's side-effecting navigation
+      and interaction tools without weakening other approval boundaries.
+    item(status="covered").
+      Live probes on July 14, 2026 used the pinned Nix package in `atom-io` and
+      then a full bootstrap and repeat bootstrap of `recoverage`. A fresh
+      non-interactive Codex task in `recoverage` connected to Playwright,
+      navigated to a dirty-space server at `http://127.0.0.1:4321`, inspected
+      its accessibility tree, clicked and typed, captured a screenshot, and
+      retrieved the expected console error and `probe.json` 200 network entry.
+      Chromium launched with its sandbox explicitly enabled.
+    item(status="covered").
+      The encoded MCP config survived repeat bootstrap in `recoverage`, and
+      the installed wrapper's runtime closure contains Chromium without the
+      Firefox or WebKit browser packages.

--- a/vms/templates/guest-apply.sh
+++ b/vms/templates/guest-apply.sh
@@ -138,6 +138,37 @@ chmod 755 "$HOME/.local/libexec/scrubs/codex-clean.nu"
 ensure_symlink "$HOME/.local/libexec/scrubs/gh-clean.sh" "$HOME/.local/bin/gh"
 ensure_symlink "$HOME/.local/libexec/scrubs/codex-clean.nu" "$HOME/.local/bin/codex"
 
+configure_codex_playwright_mcp() {
+  real_codex="/run/current-system/sw/bin/codex"
+  playwright_mcp="/run/current-system/sw/bin/codex-playwright-mcp"
+  codex_home="$HOME/.codex"
+  codex_config="$codex_home/config.toml"
+
+  if [ ! -x "$real_codex" ]; then
+    echo "scrubs bootstrap is missing Codex" >&2
+    exit 1
+  fi
+
+  mkdir -p "$codex_home"
+  chmod 700 "$codex_home"
+
+  # `nixos-rebuild boot` stages the wrapper for the reboot that follows this
+  # script. Codex accepts a future command path, so do not require it in the
+  # currently active generation.
+  CODEX_HOME="$codex_home" "$real_codex" mcp remove playwright >/dev/null 2>&1 || true
+  CODEX_HOME="$codex_home" "$real_codex" mcp add playwright -- "$playwright_mcp" >/dev/null
+  cat >>"$codex_config" <<'EOF'
+experimental_environment = "remote"
+startup_timeout_sec = 30
+tool_timeout_sec = 120
+required = true
+default_tools_approval_mode = "approve"
+EOF
+  chmod 600 "$codex_config"
+}
+
+configure_codex_playwright_mcp
+
 configure_github_git_helper() {
   gh_wrapper="$HOME/.local/bin/gh"
   github_helper_key="credential.https://github.com.helper"

--- a/vms/templates/guest-apply.sh
+++ b/vms/templates/guest-apply.sh
@@ -155,9 +155,9 @@ configure_codex_playwright_mcp() {
   # `nixos-rebuild boot` stages the wrapper for the reboot that follows this
   # script. Codex accepts a future command path, so do not require it in the
   # currently active generation.
-  CODEX_HOME="$codex_home" "$real_codex" mcp remove playwright >/dev/null 2>&1 || true
-  CODEX_HOME="$codex_home" "$real_codex" mcp add playwright -- "$playwright_mcp" >/dev/null
-  cat >>"$codex_config" <<'EOF'
+  CODEX_HOME="$codex_home" "$real_codex" mcp remove playwright > /dev/null 2>&1 || true
+  CODEX_HOME="$codex_home" "$real_codex" mcp add playwright -- "$playwright_mcp" > /dev/null
+  cat >> "$codex_config" << 'EOF'
 experimental_environment = "remote"
 startup_timeout_sec = 30
 tool_timeout_sec = 120

--- a/vms/validate.nu
+++ b/vms/validate.nu
@@ -221,6 +221,41 @@ def probe-codex-login-status [instance_name: string, label: string] {
   pass-entry $label "Codex login status succeeded without interactive login"
 }
 
+def probe-playwright-mcp-config [instance_name: string, label: string] {
+  let command = "
+test -x /run/current-system/sw/bin/codex-playwright-mcp
+codex mcp get playwright | grep -Fq 'command: /run/current-system/sw/bin/codex-playwright-mcp'
+grep -Fq 'experimental_environment = \"remote\"' \"$HOME/.codex/config.toml\"
+grep -Fq 'required = true' \"$HOME/.codex/config.toml\"
+grep -Fq 'default_tools_approval_mode = \"approve\"' \"$HOME/.codex/config.toml\"
+"
+  let result = (guest-run $instance_name $command)
+
+  if $result.exit_code != 0 {
+    return (fail-entry $label (summarize-command-failure $result "Codex Playwright MCP configuration is missing or incomplete"))
+  }
+
+  pass-entry $label "Codex has a required, pre-approved remote-STDIO Playwright MCP backed by the scrubs wrapper"
+}
+
+def probe-playwright-mcp-tools [instance_name: string, lab_dir: string, label: string] {
+  let lab_dir_q = (shell-quote $lab_dir)
+  let initialize_q = (shell-quote '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-06-18","capabilities":{},"clientInfo":{"name":"scrubs-validation","version":"1"}}}')
+  let initialized_q = (shell-quote '{"jsonrpc":"2.0","method":"notifications/initialized","params":{}}')
+  let list_tools_q = (shell-quote '{"jsonrpc":"2.0","id":2,"method":"tools/list","params":{}}')
+  let command = $"
+cd ($lab_dir_q)
+printf '%s\n' ($initialize_q) ($initialized_q) ($list_tools_q) | timeout 15 /run/current-system/sw/bin/codex-playwright-mcp --image-responses omit | grep -Fq '"name":"browser_take_screenshot"'
+"
+  let result = (guest-run $instance_name $command)
+
+  if $result.exit_code != 0 {
+    return (fail-entry $label (summarize-command-failure $result "Playwright MCP did not start or expose browser tools"))
+  }
+
+  pass-entry $label "Sandboxed Playwright MCP started and exposed browser tools over STDIO"
+}
+
 def probe-codex-canonical-home-login-status [instance_name: string, label: string] {
   let command = "
 . \"$HOME/.local/libexec/scrubs/clean-auth-lib.sh\"
@@ -479,6 +514,7 @@ def main [
   $results = ($results | append (probe-codex-canonical-home-login-status $instance_name "Codex SSH-style auth smoke"))
   $results = ($results | append (probe-gh-auth $instance_name "gh auth smoke"))
   $results = ($results | append (probe-codex-login-status $instance_name "Codex auth smoke"))
+  $results = ($results | append (probe-playwright-mcp-config $instance_name "Codex Playwright MCP config"))
 
   let marker_result = (probe-codex-marker $instance_name $marker_path $marker)
   if $marker_result.status == "PASS" {
@@ -491,6 +527,12 @@ def main [
     $lab_ready = true
   }
   $results = ($results | append $lab_setup_result)
+
+  if $lab_ready {
+    $results = ($results | append (probe-playwright-mcp-tools $instance_name $lab_dir "Codex Playwright MCP tools"))
+  } else {
+    $results = ($results | append (skip-entry "Codex Playwright MCP tools" "Skipped because the guest-local validation lab could not be prepared"))
+  }
 
   if $lab_ready {
     let tool_install_result = (install-validation-tools $instance_name $lab_dir)
@@ -532,6 +574,13 @@ def main [
   $results = ($results | append (probe-gh-auth $instance_name "gh auth smoke after re-bootstrap"))
   $results = ($results | append (probe-codex-canonical-home-login-status $instance_name "Codex SSH-style auth smoke after re-bootstrap"))
   $results = ($results | append (probe-codex-login-status $instance_name "Codex auth smoke after re-bootstrap"))
+  $results = ($results | append (probe-playwright-mcp-config $instance_name "Codex Playwright MCP config after re-bootstrap"))
+
+  if $lab_ready {
+    $results = ($results | append (probe-playwright-mcp-tools $instance_name $lab_dir "Codex Playwright MCP tools after re-bootstrap"))
+  } else {
+    $results = ($results | append (skip-entry "Codex Playwright MCP tools after re-bootstrap" "Skipped because the guest-local validation lab could not be prepared"))
+  }
 
   if $dirty_runtime_ready {
     $results = ($results | append (probe-dirty-boundary $instance_name $lab_dir "Dirty boundary smoke after re-bootstrap"))


### PR DESCRIPTION
## Summary

- package pinned Playwright MCP and its matching Chromium revision in the scrubs NixOS closure
- run the browser in an isolated bubblewrap environment while preserving access to guest-local development servers
- configure the required remote STDIO MCP server for unattended Codex tasks
- add bootstrap and validation coverage plus operator documentation

## Validation

- completed initial and repeat bootstrap of the `recoverage` guest
- ran a fresh non-interactive `codex exec` task with its normal `approval: never` policy
- navigated to `http://127.0.0.1:4321`, inspected the accessibility tree, clicked, typed, and captured a screenshot
- captured the expected console marker and a `200 OK` request for `/probe.json`
- confirmed the installed runtime closure contains Chromium without Firefox or WebKit
- passed shell syntax, Nushell parsing, and `git diff --check`
