### PR TITLE
fix(scrubs): pin Tailscale 1.98.9

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -35,7 +35,7 @@ jobs:
         with:
           version: 2026.6.11
           github_token: ${{ github.token }}
-      - run: mise exec github:nushell/nushell@0.114.0 -- just scrubs-validation-static
+      - run: mise exec github:nushell/nushell@0.114.1 -- just scrubs-validation-static
 
   Test:
     runs-on: macos-26
@@ -62,6 +62,6 @@ jobs:
         shell: zsh {0}
         env:
           VIRTUAL_HOME: ${{ github.workspace }}/home
-      - run: mise exec github:nushell/nushell@0.114.0 -- nu ${{ github.workspace }}/scripts/configure-apps.nu
+      - run: mise exec github:nushell/nushell@0.114.1 -- nu ${{ github.workspace }}/scripts/configure-apps.nu
       - run: just helix-theme-build
         shell: zsh {0}

--- a/vms/configuration.nix
+++ b/vms/configuration.nix
@@ -9,6 +9,7 @@ in
   imports = [
     ./modules/clean-base.nix
     ./modules/clean-playwright.nix
+    ./modules/clean-tailscale.nix
   ]
   ++ (if builtins.pathExists tailscaleConfigModule then [ tailscaleConfigModule ] else [ ])
   ++ (if builtins.pathExists projectShimModule then [ projectShimModule ] else [ ])

--- a/vms/modules/clean-tailscale.nix
+++ b/vms/modules/clean-tailscale.nix
@@ -1,0 +1,88 @@
+{ lib, pkgs, ... }:
+# Removal runbook for this emergency binary package:
+#
+# The readiness signal is that the nixpkgs-unstable revision pinned in
+# ../flake.lock evaluates legacyPackages.aarch64-linux.tailscale.version to
+# 1.98.9 or newer. Checking the branch alone is not sufficient; update the
+# lock first, then evaluate the pinned input with:
+#
+#   nix eval --raw --impure --expr \
+#     'let flake = builtins.getFlake (toString ./vms); in flake.inputs.nixpkgs-unstable.legacyPackages.aarch64-linux.tailscale.version'
+#
+# When that signal is received, replace this derivation with the ordinary
+# unstable package selection below, retain this module's import from
+# ../configuration.nix, and validate a disposable guest before rollout:
+#
+#   { unstablePkgs, ... }:
+#   { services.tailscale.package = unstablePkgs.tailscale; }
+#
+# Confirm `tailscale version` reports 1.98.9 or newer, tailscaled is active,
+# and Tailscale SSH works before removing the emergency override everywhere.
+let
+  version = "1.98.9";
+  sources = {
+    aarch64-linux = {
+      arch = "arm64";
+      hash = "sha256-+lVO6AjX0H7o4+u8AhXqCHFX4qCrv0CObhjqdTJVTbY=";
+    };
+    x86_64-linux = {
+      arch = "amd64";
+      hash = "sha256-Eb4wrTAdSPhP9S/sNPii946z497hvk6WJNGfzMjfVUA=";
+    };
+  };
+  source =
+    sources.${pkgs.stdenv.hostPlatform.system}
+      or (throw "tailscale-bin ${version} does not support ${pkgs.stdenv.hostPlatform.system}");
+  tailscale-bin = pkgs.stdenvNoCC.mkDerivation {
+    pname = "tailscale";
+    inherit version;
+
+    src = pkgs.fetchurl {
+      url = "https://pkgs.tailscale.com/stable/tailscale_${version}_${source.arch}.tgz";
+      inherit (source) hash;
+    };
+
+    nativeBuildInputs = [ pkgs.makeWrapper ];
+
+    dontBuild = true;
+
+    installPhase = ''
+      runHook preInstall
+
+      install -Dm755 tailscale "$out/bin/tailscale"
+      install -Dm755 tailscaled "$out/bin/tailscaled"
+      wrapProgram "$out/bin/tailscaled" \
+        --prefix PATH : ${
+          lib.makeBinPath [
+            pkgs.getent
+            pkgs.iproute2
+            pkgs.iptables
+            pkgs.shadow
+          ]
+        } \
+        --suffix PATH : ${lib.makeBinPath [ pkgs.procps ]}
+
+      sed \
+        -e "s#/usr/sbin#$out/bin#g" \
+        -e "/^EnvironmentFile=/d" \
+        systemd/tailscaled.service \
+        > tailscaled.service
+      install -Dm444 tailscaled.service "$out/lib/systemd/system/tailscaled.service"
+
+      runHook postInstall
+    '';
+
+    meta = {
+      description = "Node agent for Tailscale, a mesh VPN built on WireGuard";
+      homepage = "https://tailscale.com";
+      changelog = "https://tailscale.com/changelog#client";
+      license = lib.licenses.bsd3;
+      mainProgram = "tailscale";
+      platforms = builtins.attrNames sources;
+      sourceProvenance = [ lib.sourceTypes.binaryNativeCode ];
+    };
+  };
+in
+{
+  services.tailscale.package = tailscale-bin;
+}


### PR DESCRIPTION
## Summary

- package the official Tailscale 1.98.9 Linux binaries in clean Nix space with fixed hashes
- select the patched package for every scrubs guest while preserving the existing Tailscale SSH bootstrap behavior
- document the readiness signal and removal steps for switching to unstablePkgs.tailscale

## Removal signal

Remove the emergency derivation once the nixpkgs-unstable revision pinned in vms/flake.lock evaluates the aarch64-linux Tailscale package to 1.98.9 or newer. Replace the module with the ordinary unstablePkgs.tailscale selection, validate a disposable guest, then roll it out.

## Validation

- nix-instantiate --parse vms/modules/clean-tailscale.nix
- just scrubs-validation-static scrubs-validation-parallel-static
- rebuilt atom-io, lasertag, and tfr successfully
- verified Tailscale 1.98.9, active tailscaled, and RunSSH true on all three guests