### PR TITLE
fix(scrubs): mount Aube virtual store in dirtyspace

### DIFF
--- a/vms/templates/dirty-exec.sh
+++ b/vms/templates/dirty-exec.sh
@@ -62,6 +62,10 @@ build_runtime_cache() {
     "${cache_home_bin}" \
     "${cache_mise_state_dir}"
 
+  if [[ -n "${active_aube_store}" && "${active_aube_store}" == "${HOME}/"* ]]; then
+    mkdir -p "${cache_home}/${active_aube_store#"${HOME}/"}"
+  fi
+
   write_exec_wrapper /usr/bin/mise "${cache_home_bin}/mise"
 
   for spec in "${runtime_wrapper_specs[@]}"; do
@@ -133,6 +137,21 @@ mise_root="${HOME}/.local/share/mise"
 mise_shims="${mise_root}/shims"
 mise_config_dir="${HOME}/.config/mise"
 mise_state_dir="${HOME}/.local/state/mise"
+# Embedded Aube leaves mise package links pointing into this materialized
+# package tree. Expose only that exact subtree, never the surrounding cache.
+xdg_cache_home="${XDG_CACHE_HOME:-}"
+if [[ -z "${xdg_cache_home}" || "${xdg_cache_home}" != /* ]]; then
+  xdg_cache_home="${HOME}/.cache"
+fi
+if [[ "${xdg_cache_home}" == "/" ]]; then
+  aube_store="/aube/virtual-store"
+else
+  aube_store="${xdg_cache_home%/}/aube/virtual-store"
+fi
+active_aube_store=""
+if [[ -d "${aube_store}" ]]; then
+  active_aube_store="${aube_store}"
+fi
 scrubs_rustup_home="${mise_root}/rustup-home"
 scrubs_rust_bootstrap_cargo_home="${mise_root}/rust-cargo-home"
 runtime_cache_root="/tmp/scrubs-dirty-runtime-cache/${current_user}"
@@ -142,7 +161,7 @@ ssl_cert_file="/etc/ssl/certs/ca-bundle.crt"
 nix_ld="/run/current-system/sw/share/nix-ld/lib/ld.so"
 nix_ld_library_path="/run/current-system/sw/share/nix-ld/lib"
 guest_loader=""
-runtime_cache_version="4"
+runtime_cache_version="5"
 helper_closure_cache_version="2"
 
 resolved_target="$(resolve_mise_target "${command_name}")"
@@ -198,6 +217,7 @@ runtime_cache_key="$(
   printf '%s\n' \
     "${runtime_cache_version}" \
     "${project_root}" \
+    "${active_aube_store}" \
     "${runtime_wrapper_specs[@]}" \
     | cksum \
     | awk '{print $1 "-" $2}'
@@ -216,6 +236,7 @@ declare -a sandbox_dirs=()
 declare -A seen_sandbox_dirs=()
 declare -a extra_ro_binds=()
 declare -a helper_file_binds=()
+declare -a aube_store_bind=()
 
 append_cached_store_path() {
   local closure_path="$1"
@@ -257,6 +278,14 @@ append_parent_dirs() {
     current_parent="$(dirname "${current_parent}")"
   done
 }
+
+if [[ -n "${active_aube_store}" ]]; then
+  if [[ "${active_aube_store}" != "${HOME}/"* ]]; then
+    append_parent_dirs "${active_aube_store}"
+    append_sandbox_dir "${active_aube_store}"
+  fi
+  aube_store_bind=(--ro-bind "${active_aube_store}" "${active_aube_store}")
+fi
 
 if [[ -d "${helper_root}" ]]; then
   while IFS= read -r helper_entry; do
@@ -378,6 +407,7 @@ exec "${BWRAP_BIN}" \
   "${helper_file_binds[@]}" \
   "${extra_ro_binds[@]}" \
   --bind "${fake_home}" "/home/${current_user}" \
+  "${aube_store_bind[@]}" \
   --ro-bind "${mise_root}" "/home/${current_user}/.local/share/mise" \
   --ro-bind "${mise_config_dir}" "/home/${current_user}/.config/mise" \
   --bind "${project_root}" "${project_root}" \

--- a/vms/validate.nu
+++ b/vms/validate.nu
@@ -301,14 +301,26 @@ git init -b main >/dev/null
 cat > .mise.toml <<'EOF'
 [tools]
 just = \"1.52.0\"
+ni = \"30.5.0\"
+node = \"24\"
 EOF
 cat > justfile <<'EOF'
 probe-dirty-boundary:
     test ! -e \"$HOME/.local/share/scrubs/clean-auth\"
     ! command -v gh >/dev/null 2>&1
     ! command -v codex >/dev/null 2>&1
+
+probe-aube-runtime:
+    ni --version >/dev/null
+    aube_store=\"$HOME/.cache/scrubs-validation-xdg/aube/virtual-store\"; test -d \"$aube_store\"
+    aube_store=\"$HOME/.cache/scrubs-validation-xdg/aube/virtual-store\"; ! touch \"$aube_store/.scrubs-write-probe\" >/dev/null 2>&1
+    test ! -e \"$HOME/.cache/scrubs-validation-secret\"
+    test ! -e \"$HOME/.local/share/scrubs-validation-secret\"
 EOF
 printf 'scrubs validation lab\n' > README.md
+mkdir -p \"$HOME/.cache\" \"$HOME/.local/share\"
+printf 'cache boundary probe\n' > \"$HOME/.cache/scrubs-validation-secret\"
+printf 'data boundary probe\n' > \"$HOME/.local/share/scrubs-validation-secret\"
 git config user.name 'Scrubs Validation'
 git config user.email 'scrubs-validation@example.invalid'
 git add . >/dev/null
@@ -325,13 +337,13 @@ git commit -m 'Initialize scrubs validation lab' >/dev/null
 
 def install-validation-tools [instance_name: string, lab_dir: string] {
   let lab_dir_q = (shell-quote $lab_dir)
-  let result = (guest-run $instance_name $"cd ($lab_dir_q) && mise trust .mise.toml >/dev/null && mise install >/dev/null")
+  let result = (guest-run $instance_name $"cd ($lab_dir_q) && mise trust .mise.toml >/dev/null && XDG_CACHE_HOME=\"$HOME/.cache/scrubs-validation-xdg\" mise install >/dev/null")
 
   if $result.exit_code != 0 {
     return (fail-entry "Validation lab tool install" (summarize-command-failure $result "mise install failed for the validation lab"))
   }
 
-  pass-entry "Validation lab tool install" "Installed the dirty-space `just` runtime for the guest-local fixture"
+  pass-entry "Validation lab tool install" "Installed the dirty-space `just`, `ni`, and Node runtimes for the guest-local fixture"
 }
 
 def probe-dirty-boundary [instance_name: string, lab_dir: string, label: string] {
@@ -343,6 +355,17 @@ def probe-dirty-boundary [instance_name: string, lab_dir: string, label: string]
   }
 
   pass-entry $label "Dirty space could not see clean-auth, gh, or codex"
+}
+
+def probe-aube-runtime [instance_name: string, lab_dir: string, label: string] {
+  let lab_dir_q = (shell-quote $lab_dir)
+  let result = (guest-run $instance_name $"cd ($lab_dir_q) && XDG_CACHE_HOME=\"$HOME/.cache/scrubs-validation-xdg\" just probe-aube-runtime >/dev/null")
+
+  if $result.exit_code != 0 {
+    return (fail-entry $label (summarize-command-failure $result "The dirty-space Aube runtime or isolation probe failed"))
+  }
+
+  pass-entry $label "Dirty-space `ni` resolved its Aube-backed packages while the store stayed read-only and unrelated user data stayed hidden"
 }
 
 def probe-git-credential-fill [instance_name: string, label: string] {
@@ -546,8 +569,10 @@ def main [
 
   if $dirty_runtime_ready {
     $results = ($results | append (probe-dirty-boundary $instance_name $lab_dir "Dirty boundary smoke"))
+    $results = ($results | append (probe-aube-runtime $instance_name $lab_dir "Aube-backed dirty runtime"))
   } else {
     $results = ($results | append (skip-entry "Dirty boundary smoke" "Skipped because the guest-local dirty fixture could not be initialized"))
+    $results = ($results | append (skip-entry "Aube-backed dirty runtime" "Skipped because the guest-local dirty fixture could not be initialized"))
   }
 
   $results = ($results | append (probe-git-credential-fill $instance_name "HTTPS Git credential helper smoke"))
@@ -584,8 +609,10 @@ def main [
 
   if $dirty_runtime_ready {
     $results = ($results | append (probe-dirty-boundary $instance_name $lab_dir "Dirty boundary smoke after re-bootstrap"))
+    $results = ($results | append (probe-aube-runtime $instance_name $lab_dir "Aube-backed dirty runtime after re-bootstrap"))
   } else {
     $results = ($results | append (skip-entry "Dirty boundary smoke after re-bootstrap" "Skipped because the guest-local dirty fixture never initialized"))
+    $results = ($results | append (skip-entry "Aube-backed dirty runtime after re-bootstrap" "Skipped because the guest-local dirty fixture never initialized"))
   }
 
   $results = ($results | append (probe-git-credential-fill $instance_name "HTTPS Git credential helper smoke after re-bootstrap"))


### PR DESCRIPTION
## Summary
- discover the active Aube virtual store from XDG_CACHE_HOME with the standard fallback
- create its synthetic-home mount point and bind only that subtree read-only after mounting the synthetic home
- bump the dirty runtime cache version and key caches by the active store path
- extend Scrubs validation with ni 30.5.0, a custom XDG cache location, write rejection, unrelated cache/data isolation, and repeat-bootstrap coverage

## Validation
- just fmt-check
- just scrubs-validation-static
- bash -n vms/templates/dirty-exec.sh
- disposable Scrubs validation: 26 passed, 0 failed, 1 intentionally skipped HTTPS push dry-run probe