### PR TITLE
Map TFR development ports directly

### DIFF
--- a/vms/projects/tfr/lima.yaml
+++ b/vms/projects/tfr/lima.yaml
@@ -1,0 +1,7 @@
+portForwards:
+  - guestPort: 3000
+    hostPort: 3000
+    proto: tcp
+  - guestPort: 4569
+    hostPort: 4569
+    proto: tcp


### PR DESCRIPTION
## Summary
- map TFR guest port 3000 directly to host port 3000
- map TFR guest port 4569 directly to host port 4569

## Verification
- bootstrapped the tfr guest
- just lima-ports tfr reports 3000 -> 3000 and 4569 -> 4569

## Dependency
This is stacked on the port-forward override PR so the explicit port 3000 mapping replaces the generated default.