### PR TITLE
Add Bun command aliases

### DIFF
--- a/home/.config/nushell/ni-completions.nu
+++ b/home/.config/nushell/ni-completions.nu
@@ -247,3 +247,27 @@ export extern "nd" [
     -c
     ...args: string
 ]
+
+export alias bi = bun install
+
+export def --wrapped br [
+    script?: string@"nu-complete nr scripts"
+    ...args: string
+] {
+    if $script == null {
+        ^bun run ...$args
+    } else {
+        ^bun run $script ...$args
+    }
+}
+
+export def --wrapped ba [
+    bin?: string@"nu-complete na bins"
+    ...args: string
+] {
+    if $bin == null {
+        ^bun run ...$args
+    } else {
+        ^bun run $bin ...$args
+    }
+}


### PR DESCRIPTION
## Summary

- add `bi` as an alias for `bun install`
- add `br` as a `bun run` wrapper with package script completion
- add `ba` as a `bun run` wrapper with local binary completion

## Validation

- loaded the module with Nushell 0.115.1
- verified the exported commands and alias
- ran `git diff --check`