### PR TITLE
Upgrade mise and Renovate workflow dependencies

### DIFF
--- a/.github/workflows/integration.yml
+++ b/.github/workflows/integration.yml
@@ -20,9 +20,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          version: 2026.8.0
+          version: 2026.8.14
           github_token: ${{ github.token }}
       - run: just fmt-check
 
@@ -31,9 +31,9 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          version: 2026.8.0
+          version: 2026.8.14
           github_token: ${{ github.token }}
       - run: mise exec github:nushell/nushell@0.114.1 -- just scrubs-validation-static
 
@@ -42,9 +42,9 @@ jobs:
     timeout-minutes: 15
     steps:
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: jdx/mise-action@7e36c90d9ab29c415a2384db3006f3ec8a8cc654 # v4.2.4
+      - uses: jdx/mise-action@c2a87611a18de5b3828c5652fe268e992400cb5c # v4.3.0
         with:
-          version: 2026.8.0
+          version: 2026.8.14
           github_token: ${{ github.token }}
       - name: Ensure Homebrew
         shell: zsh {0}

--- a/.github/workflows/renovate.yml
+++ b/.github/workflows/renovate.yml
@@ -38,7 +38,7 @@ jobs:
           permission-issues: write
           permission-statuses: write
       - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
-      - uses: renovatebot/github-action@316d7cd859606d6039a2182b7d69199e9b036835 # v46.2.1
+      - uses: renovatebot/github-action@5402b206248e5a8c8427a15102702eb9c1793efc # v46.2.4
         env:
           LOG_LEVEL: debug
           RENOVATE_ALLOW_PLUGINS: true


### PR DESCRIPTION
## Summary

- upgrade jdx/mise from 2026.8.0 to 2026.8.14
- upgrade jdx/mise-action from v4.2.4 to v4.3.0
- upgrade renovatebot/github-action from v46.2.1 to v46.2.4
- refresh pinned action commit SHAs with the repository upgrade script

## Validation

- just upgrade-workflows-dry-run
- just fmt-check
- git diff --check